### PR TITLE
significant performance boost in Kore VertexBuffer

### DIFF
--- a/Backends/Kore/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Kore/kha/graphics4/VertexBuffer.hx
@@ -9,6 +9,7 @@ import kha.graphics4.VertexStructure;
 @:headerCode('
 #include <Kore/pch.h>
 #include <Kore/Graphics/Graphics.h>
+#include <string.h>
 ')
 
 @:headerClassCode("Kore::VertexBuffer* buffer;")
@@ -55,9 +56,7 @@ class VertexBuffer {
 	@:functionCode("
 		float* vertices = buffer->lock();
 		float* pointer = (float*)bytes->Pointer();
-		for (int i = 0; i < buffer->count() * buffer->stride() / 4; ++i) {
-			vertices[i] = pointer[i];
-		}
+        memcpy(vertices, pointer, buffer->myCount * buffer->myStride / 4);
 		buffer->unlock();
 	")
 	private function unlock2(bytes: BytesData): Void {


### PR DESCRIPTION
I've discovered this fix with MSVS 2013 Profiler and this tool still point to `memcpy` in this fix as one of the functions doing most individual work:
![2015-06-27_072011](https://cloud.githubusercontent.com/assets/7815518/8390433/315da9e0-1c9d-11e5-9adc-54851fdc0290.jpg)
This fix requires numerous edits in Kore VertexBuffer backends, something like:
```
    public:
        int myCount;
        int myStride;
    protected:
```