### PR TITLE
Small fixes for WPF

### DIFF
--- a/Backends/WPF/kha/Starter.hx
+++ b/Backends/WPF/kha/Starter.hx
@@ -332,7 +332,9 @@ class Starter {
 	}
 
 	@:functionCode('
-		new System.Windows.Application().Run(mainWindow);
+		if (System.Windows.Application.Current == null) {
+			new System.Windows.Application().Run(mainWindow);
+		}
 	')
 	static function startWindow() : Void {
 		

--- a/Backends/WPF/kha/graphics4/VertexBuffer.hx
+++ b/Backends/WPF/kha/graphics4/VertexBuffer.hx
@@ -1,8 +1,8 @@
 package kha.graphics4;
-
+import haxe.io.Float32Array;
 class VertexBuffer {
 	public function new(vertexCount: Int, structure: VertexStructure, usage: Usage, canRead: Bool = false) { }
-	public function lock(?start: Int, ?count: Int): Array<Float> { return null; }
+	public function lock(?start: Int, ?count: Int): Float32Array { return null; }
 	public function unlock(): Void { }
 	public function count(): Int { return 0; }
 	public function stride(): Int { return 1; }


### PR DESCRIPTION
This section in Starter.hx:
		if (Application.Current == null) {
			new System.Windows.Application().Run(mainWindow);
		}

is useful if we use it as .dll, because in this case, Application is created already.

