### PR TITLE
make sure the canvas size in pixels match the canvas size on screen

### DIFF
--- a/Backends/HTML5/kha/Starter.hx
+++ b/Backends/HTML5/kha/Starter.hx
@@ -189,6 +189,21 @@ class Starter {
 			Scheduler.executeFrame();
 			
 			if (canvas.getContext) {
+
+				// Lookup the size the browser is displaying the canvas.
+				//TODO deal with window.devicePixelRatio ?
+				var displayWidth  = canvas.clientWidth;
+				var displayHeight = canvas.clientHeight;
+
+				// Check if the canvas is not the same size.
+				if (canvas.width  != displayWidth ||
+					canvas.height != displayHeight) {
+
+					// Make the canvas the same size
+					canvas.width  = displayWidth;
+					canvas.height = displayHeight;
+				}
+
 				Configuration.screen().render(frame);
 				if (Sys.gl != null) {
 					// Clear alpha for IE11


### PR DESCRIPTION
This small change ensure the browser do not scale the content of the canvas to fit the visual size of the canvas. 
While this has no benefit when used with a fixed size canvas but benefit all the other cases.