### PR TITLE
Fixed typo in html5 sound loader.

### DIFF
--- a/Backends/HTML5/kha/js/Loader.hx
+++ b/Backends/HTML5/kha/js/Loader.hx
@@ -43,7 +43,7 @@ class Loader extends kha.Loader {
 				}
 			}
 		}
-		else new Sound(desc.file, done);
+		else new Sound(desc.files, done);
 	}
 	
 	override function loadImage(desc: Dynamic, done: kha.Image -> Void) {


### PR DESCRIPTION
Was causing crashes on browsers without webaudio.