### PR TITLE
Fixed scheduler deleting at max one inactive task per frame.

### DIFF
--- a/Sources/kha/Scheduler.hx
+++ b/Sources/kha/Scheduler.hx
@@ -194,29 +194,31 @@ class Scheduler {
 		
 		current = frameEnd;
 		
-		while (true) {
-			for (timeTask in timeTasks) {
-				if (!timeTask.active) {
-					timeTasks.remove(timeTask);
-					break;
-				}
+		var toDeleteTime : Array<TimeTask> = new Array<TimeTask>();
+		for (timeTask in timeTasks) {
+			if (!timeTask.active) {
+				toDeleteTime.push(timeTask);
 			}
-			break;
+		}
+		
+		for (timeTask in toDeleteTime) {
+			timeTasks.remove(timeTask);
 		}
 
 		sortFrameTasks();
 		for (frameTask in frameTasks) {
 			if (!frameTask.task()) frameTask.active = false;
 		}
-
-		while (true) {
-			for (frameTask in frameTasks) {
-				if (!frameTask.active) {
-					frameTasks.remove(frameTask);
-					break;
-				}
+		
+		var toDeleteFrame : Array<FrameTask> = new Array<FrameTask>();
+		for (frameTask in frameTasks) {
+			if (!frameTask.active) {
+				toDeleteFrame.push(frameTask);
 			}
-			break;
+		}
+		
+		for (frameTask in toDeleteFrame) {
+			frameTasks.remove(frameTask);
 		}
 	}
 


### PR DESCRIPTION
Same principle as my last fix - this time I checked the complete scheduler for remaining instances of the same pattern.