### PR TITLE
add fullscreen switch calls for html5 + Kore + empty implementations …

### DIFF
--- a/Backends/Android/kha/Sys.hx
+++ b/Backends/Android/kha/Sys.hx
@@ -70,4 +70,29 @@ class Sys {
 	public static function requestShutdown(): Void {
 		
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }

--- a/Backends/Flash/kha/Sys.hx
+++ b/Backends/Flash/kha/Sys.hx
@@ -52,4 +52,30 @@ class Sys {
 		Game.the.onShutdown();
 		flash.Lib.fscommand("quit");
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
 }

--- a/Backends/HTML5-Worker/kha/Sys.hx
+++ b/Backends/HTML5-Worker/kha/Sys.hx
@@ -43,4 +43,29 @@ class Sys {
 	public static function refreshRate(): Int {
 		return 60;
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }

--- a/Backends/HTML5/kha/Sys.hx
+++ b/Backends/HTML5/kha/Sys.hx
@@ -62,4 +62,69 @@ class Sys {
 	public static function requestShutdown(): Void {
 		Browser.window.close();
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return untyped __js__("'fullscreenElement ' in document ||
+        'mozFullScreenElement' in document ||
+        'webkitFullscreenElement' in document ||
+        'msFullscreenElement' in document
+        ");
+	}
+
+	public static function isFullscreen() : Bool{
+		return untyped __js__("document.fullscreenElement === this.khanvas ||
+  			document.mozFullScreenElement === this.khanvas ||
+  			document.webkitFullscreenElement === this.khanvas ||
+  			document.msFullscreenElement === this.khanvas ");
+	}
+
+	public static function requestFullscreen(): Void {
+		untyped if (khanvas.requestFullscreen) {
+        	khanvas.requestFullscreen();
+        } else if (khanvas.msRequestFullscreen) {
+        	khanvas.msRequestFullscreen();
+        } else if (khanvas.mozRequestFullScreen) {
+        	khanvas.mozRequestFullScreen();
+        } else if(khanvas.webkitRequestFullscreen){
+        	khanvas.webkitRequestFullscreen();
+        }
+	}
+
+	public static function exitFullscreen(): Void {
+		untyped if (document.exitFullscreen) {
+	      document.exitFullscreen();
+	    } else if (document.msExitFullscreen) {
+	      document.msExitFullscreen();
+	    } else if (document.mozCancelFullScreen) {
+	      document.mozCancelFullScreen();
+	    } else if (document.webkitExitFullscreen) {
+	      document.webkitExitFullscreen();
+	    }
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		js.Browser.document.addEventListener('fullscreenchange', func, false);
+		js.Browser.document.addEventListener('mozfullscreenchange', func, false);
+		js.Browser.document.addEventListener('webkitfullscreenchange', func, false);
+		js.Browser.document.addEventListener('MSFullscreenChange', func, false);
+
+		js.Browser.document.addEventListener('fullscreenerror', error, false);
+		js.Browser.document.addEventListener('mozfullscreenerror', error, false);
+		js.Browser.document.addEventListener('webkitfullscreenerror', error, false);
+		js.Browser.document.addEventListener('MSFullscreenError', error, false);
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		js.Browser.document.removeEventListener('fullscreenchange', func, false);
+		js.Browser.document.removeEventListener('mozfullscreenchange', func, false);
+		js.Browser.document.removeEventListener('webkitfullscreenchange', func, false);
+		js.Browser.document.removeEventListener('MSFullscreenChange', func, false);
+
+		js.Browser.document.removeEventListener('fullscreenerror', error, false);
+		js.Browser.document.removeEventListener('mozfullscreenerror', error, false);
+		js.Browser.document.removeEventListener('webkitfullscreenerror', error, false);
+		js.Browser.document.removeEventListener('MSFullscreenError', error, false);
+	}
+
 }

--- a/Backends/Java/kha/Sys.hx
+++ b/Backends/Java/kha/Sys.hx
@@ -47,4 +47,29 @@ class Sys {
 	public static function requestShutdown(): Void {
 		
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }

--- a/Backends/Kore/kha/Starter.hx
+++ b/Backends/Kore/kha/Starter.hx
@@ -100,16 +100,20 @@ class Starter {
 	}
 
 	public static function lockMouse(): Void {
-		untyped __cpp__("Kore::Mouse::the()->lock();");
-		for (listener in mouseLockListeners) {
-			listener();
+		if(!isMouseLocked()){
+			untyped __cpp__("Kore::Mouse::the()->lock();");
+			for (listener in mouseLockListeners) {
+				listener();
+			}	
 		}
 	}
 	
 	public static function unlockMouse(): Void {
-		untyped __cpp__("Kore::Mouse::the()->unlock();");	
-		for (listener in mouseLockListeners) {
-			listener();
+		if(isMouseLocked()){
+			untyped __cpp__("Kore::Mouse::the()->unlock();");	
+			for (listener in mouseLockListeners) {
+				listener();
+			}	
 		}
 	}
 

--- a/Backends/Node/kha/Sys.hx
+++ b/Backends/Node/kha/Sys.hx
@@ -62,4 +62,29 @@ class Sys {
 	public static function requestShutdown(): Void {
 		Node.process.exit(0);
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }

--- a/Backends/PSM/kha/Sys.hx
+++ b/Backends/PSM/kha/Sys.hx
@@ -47,4 +47,29 @@ class Sys {
 	public static function refreshRate(): Int {
 		return 60;
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }

--- a/Backends/Unity/kha/Sys.hx
+++ b/Backends/Unity/kha/Sys.hx
@@ -43,4 +43,29 @@ class Sys {
 	public static function refreshRate(): Int {
 		return 60;
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }

--- a/Backends/WPF/kha/Sys.hx
+++ b/Backends/WPF/kha/Sys.hx
@@ -46,4 +46,29 @@ class Sys {
 	public static function requestShutdown(): Void {
 		
 	}
+
+	public static function canSwitchFullscreen() : Bool{
+		return false;
+	}
+
+	public static function isFullscreen() : Bool{
+		return false;
+	}
+
+	public static function requestFullscreen(): Void {
+		
+	}
+
+	public static function exitFullscreen(): Void {
+		
+  	}
+
+	public function notifyOfFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
+
+
+	public function removeFromFullscreenChange(func : Void -> Void, error  : Void -> Void) : Void{
+		
+	}
 }


### PR DESCRIPTION
…for the rest

The Kore implementation has been tested only on windows and because the changeResolution function on Windows is not setting the window to fullscreen, it does not work yet. 
But the call  from haxe should stay like this.