### PR TITLE
setFloats() array size

### DIFF
--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -442,7 +442,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 	
 	@:functionCode('
-		float v[100];
+		float v[values->length];
 		for (int i = 0; i < values->length; ++i) v[i] = values[i];
 		Kore::Graphics::setFloats(location->location, v, values->length);
 	')


### PR DESCRIPTION
Hello,

Any reason to max this out at 100?

I finally got to implement GPU skinning, and did so using setFloats(). For 50 bones I need array of 600 floats(12 per bone). Everything seems to work fine, but I'm wondering if there would be any difference in speed using float[600] vs vec4[150] (non-existant on Kha).
