### PR TITLE
Fixed html5 VertexBuffer.set for matrices.

### DIFF
--- a/Backends/HTML5/kha/graphics4/VertexBuffer.hx
+++ b/Backends/HTML5/kha/graphics4/VertexBuffer.hx
@@ -102,7 +102,7 @@ class VertexBuffer {
 			if (sizes[i] > 4) {
 				var size = sizes[i];
 				var addonOffset = 0;
-				while (size >= 0) {
+				while (size > 0) {
 					SystemImpl.gl.enableVertexAttribArray(offset + attributesOffset);
 					SystemImpl.gl.vertexAttribPointer(offset + attributesOffset, 4, SystemImpl.gl.FLOAT, false, myStride, offsets[i] + addonOffset);
 					if (ext) {


### PR DESCRIPTION
Just a small off-by-one, resulting in the loop being called one more time. Did work when there was only one matrix at the last position, failed otherwise.