### PR TITLE
Fix application state callbacks

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -304,6 +304,8 @@ class SystemImpl {
 		canvas.onmousemove = mouseMove;
 		canvas.onkeydown = keyDown;
 		canvas.onkeyup = keyUp;
+		canvas.onblur = onBlur;
+		canvas.onfocus = onFocus;
 		untyped if (canvas.onwheel) canvas.onwheel = mouseWheel;
 		else if (canvas.onmousewheel) canvas.onmousewheel = mouseWheel;
 		canvas.addEventListener("wheel mousewheel", mouseWheel, false);
@@ -478,6 +480,16 @@ class SystemImpl {
 			surface.sendMoveEvent(touch.identifier, touchX, touchY);
 			index++;
 		}
+	}
+
+	private static function onBlur() {
+		// System.pause();
+		System.background();
+	}
+
+	private static function onFocus() {
+		// System.resume();
+		System.foreground();
 	}
 	
 	private static function keycodeToChar(key: String, keycode: Int, shift: Bool): String {

--- a/Backends/Kore/kha/SystemImpl.hx
+++ b/Backends/Kore/kha/SystemImpl.hx
@@ -362,23 +362,23 @@ class SystemImpl {
 	}
 
 	public static function foreground(): Void {
-		
+		System.foreground();
 	}
 
 	public static function resume(): Void {
-		
+		System.resume();
 	}
 
 	public static function pause(): Void {
-		
+		System.pause();
 	}
 
 	public static function background(): Void {
-		
+		System.background();
 	}
 
 	public static function shutdown(): Void {
-		
+		System.shutdown();
 	}
 	
 	@:functionCode('init_kore(name, width, height);')


### PR DESCRIPTION
Tested on android-native and HTML5 with code below:

    System.notifyOnApplicationState(function () {
			// foreground
			trace("onForeground");
		}, function () {
			// resume
			trace("onResume");
		}, function () {
			// pause
			trace("onPause");
		}, function () {
			// background
			trace("onBackground");
		}, function () {
			// shutdown
			trace("onShutdown");
		});

In HTML5 target, only onBackground (onblur) and onForeground (onfocus) is triggered.