### PR TITLE
Made transformation between glViewport and glScissor consistent.

### DIFF
--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -99,7 +99,8 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function viewport(x: Int, y: Int, width: Int, height: Int): Void{
-		SystemImpl.gl.viewport(x,y,width,height);
+		var h: Int = renderTarget == null ? System.pixelHeight : renderTarget.height;
+		SystemImpl.gl.viewport(x, h - y - height, width, height);
 	}
 	
 	public function setDepthMode(write: Bool, mode: CompareMode): Void {


### PR DESCRIPTION
In glScissor y inversion ist taken into account, but not in glViewport. This results in incompatible behaviour when called with the same values. I therefore suggest also making this transformation in glViewport.