### PR TITLE
Added stencil bindings for kore.

### DIFF
--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -35,6 +35,49 @@ import kha.Video;
 #include <Kore/Graphics/Graphics.h>
 ')
 
+@:cppFileCode('
+Kore::ZCompareMode convertCompareMode(int mode) {
+	switch (mode) {
+	case 0:
+		return Kore::ZCompareAlways;
+	case 1:
+		return Kore::ZCompareNever;
+	case 2:
+		return Kore::ZCompareEqual;
+	case 3:
+		return Kore::ZCompareNotEqual;
+	case 4:
+		return Kore::ZCompareLess;
+	case 5:
+		return Kore::ZCompareLessEqual;
+	case 6:
+		return Kore::ZCompareGreater;
+	case 7:
+		return Kore::ZCompareGreaterEqual;
+	}
+}
+
+Kore::StencilAction convertStencilAction(int action) {
+	switch (action) {
+	case 0:
+		return Kore::Keep;
+	case 1:
+		return Kore::Zero;
+	case 2:
+		return Kore::Replace;
+	case 3:
+		return Kore::Increment;
+	case 4:
+		return Kore::IncrementWrap;
+	case 5:
+		return Kore::Decrement;
+	case 6:
+		return Kore::DecrementWrap;
+	case 7:
+		return Kore::Invert;	
+	}
+}
+')
 class Graphics implements kha.graphics4.Graphics {
 	private var target: Image;
 	
@@ -218,8 +261,15 @@ class Graphics implements kha.graphics4.Graphics {
 		return null;
 	}
 	
-	public function setStencilParameters(compareMode: CompareMode, bothPass: StencilAction, depthFail: StencilAction, stencilFail: StencilAction, referenceValue: Int, readMask: Int = 0xff, writeMask: Int = 0xff): Void {
+	@:functionCode('
+		Kore::Graphics::setStencilParameters(convertCompareMode(compareMode), convertStencilAction(bothPass), convertStencilAction(depthFail), convertStencilAction(stencilFail), referenceValue, readMask, writeMask);
+	')
+	private function setStencilParameters2(compareMode: Int, bothPass: Int, depthFail: Int, stencilFail: Int, referenceValue: Int, readMask: Int, writeMask: Int): Void {
 		
+	}
+	
+	public function setStencilParameters(compareMode: CompareMode, bothPass: StencilAction, depthFail: StencilAction, stencilFail: StencilAction, referenceValue: Int, readMask: Int = 0xff, writeMask: Int = 0xff): Void {
+		setStencilParameters2(compareMode.getIndex(), bothPass.getIndex(), depthFail.getIndex(), stencilFail.getIndex(), referenceValue, readMask, writeMask);
 	}
 	
 	@:functionCode('
@@ -344,7 +394,7 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setPipeline(pipe: PipelineState): Void {
 		setCullMode(pipe.cullMode);
 		setDepthMode(pipe.depthWrite, pipe.depthMode);
-		setStencilParameters(pipe.stencilMode, pipe.stencilBothPass, pipe.stencilDepthFail, pipe.stencilFail, pipe.stencilReferenceValue, pipe.stencilReferenceValue, pipe.stencilWriteMask);
+		setStencilParameters(pipe.stencilMode, pipe.stencilBothPass, pipe.stencilDepthFail, pipe.stencilFail, pipe.stencilReferenceValue, pipe.stencilReadMask, pipe.stencilWriteMask);
 		setBlendingMode(pipe.blendSource, pipe.blendDestination);
 		pipe.set();
 	}


### PR DESCRIPTION
Succesfulls tested with Kharira on Windows using OpenGL.

Enum conversion feels a bit hacky, maybe there is some room for improvement there.