### PR TITLE
Enabled depth + stencil buffer in flash target

### DIFF
--- a/Backends/Flash/kha/SystemImpl.hx
+++ b/Backends/Flash/kha/SystemImpl.hx
@@ -60,7 +60,7 @@ class SystemImpl {
 	
 	private static function onReady(_): Void {
 		context = stage3D.context3D;
-		context.configureBackBuffer(width, height, 0, false);
+		context.configureBackBuffer(width, height, 0, true);
 		keyboard = new Keyboard();
 		mouse = new MouseImpl();
 
@@ -244,7 +244,7 @@ class SystemImpl {
 	
 	private static function resizeHandler(event: Event): Void {
 		if (frame != null && stage.stageWidth >= 32 && stage.stageHeight >= 32) {
-			context.configureBackBuffer(stage.stageWidth, stage.stageHeight, 0, false);
+			context.configureBackBuffer(stage.stageWidth, stage.stageHeight, 0, true);
 		}
 	}
 	

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -247,7 +247,7 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setPipeline(pipe: PipelineState): Void {
 		setCullMode(pipe.cullMode);
 		setDepthMode(pipe.depthWrite, pipe.depthMode);
-		setStencilParameters(pipe.stencilMode, pipe.stencilBothPass, pipe.stencilDepthFail, pipe.stencilFail, pipe.stencilReferenceValue, pipe.stencilReferenceValue, pipe.stencilWriteMask);
+		setStencilParameters(pipe.stencilMode, pipe.stencilBothPass, pipe.stencilDepthFail, pipe.stencilFail, pipe.stencilReferenceValue, pipe.stencilReadMask, pipe.stencilWriteMask);
 		setBlendingMode(pipe.blendSource, pipe.blendDestination);
 		pipe.set();
 	}


### PR DESCRIPTION
Fixed wrong parameter given to setStencilParameters (stencilReadMask instead of stencilReferenceValue)

Not sure if it's a good idea to hardcode context.configureBackBuffer(..., true), maybe add some SystemOptions to kha.System.init()? I kinda like the luxe style of passing options, so you don't end up with a gazillion parameters. Like

```haxe
kha.System.init({
    title : 'YadaYada',
    width : 800, height : 600,
    depthAndStencil : true,
}, myCallback);
```
