### PR TITLE
Android/HTML5: Support for depth/stencil buffers

### DIFF
--- a/Backends/Android/android/opengl/GLES11Ext.hx
+++ b/Backends/Android/android/opengl/GLES11Ext.hx
@@ -1,0 +1,7 @@
+package android.opengl;
+
+class GLES11Ext {
+	public static var GL_DEPTH_STENCIL_OES: Int;
+	public static var GL_DEPTH24_STENCIL8_OES: Int;
+	public static var GL_UNSIGNED_INT_24_8_OES: Int;
+}

--- a/Backends/Android/android/opengl/GLES20.hx
+++ b/Backends/Android/android/opengl/GLES20.hx
@@ -36,7 +36,11 @@ extern class GLES20 {
 	public static var GL_RGBA: Int;
 	public static var GL_UNSIGNED_BYTE: Int;
 	public static var GL_FRAMEBUFFER: Int;
+	public static var GL_RENDERBUFFER: Int;
 	public static var GL_COLOR_ATTACHMENT0: Int;
+	public static var GL_DEPTH_ATTACHMENT: Int;
+	public static var GL_STENCIL_ATTACHMENT: Int;
+	public static var GL_DEPTH_COMPONENT16: Int;
 	public static var GL_LUMINANCE: Int;
 	public static var GL_DEPTH_BUFFER_BIT: Int;
 	public static var GL_STENCIL_BUFFER_BIT: Int;
@@ -62,7 +66,31 @@ extern class GLES20 {
 	public static var GL_NEAREST_MIPMAP_LINEAR: Int;
 	public static var GL_LINEAR_MIPMAP_NEAREST: Int;
 	public static var GL_LINEAR_MIPMAP_LINEAR: Int;
-	
+
+	public static var GL_STENCIL_TEST : Int;
+	public static var GL_STENCIL_FUNC : Int;
+	public static var GL_STENCIL_FAIL : Int;
+	public static var GL_STENCIL_PASS_DEPTH_FAIL : Int;
+	public static var GL_STENCIL_PASS_DEPTH_PASS : Int;
+	public static var GL_STENCIL_REF : Int;
+	public static var GL_STENCIL_VALUE_MASK : Int;
+	public static var GL_STENCIL_WRITEMASK : Int;
+	public static var GL_STENCIL_INDEX8 : Int;
+
+	public static var GL_KEEP : Int;
+	public static var GL_REPLACE : Int;
+	public static var GL_INCR : Int;
+	public static var GL_DECR : Int;
+	public static var GL_INVERT : Int;
+	public static var GL_INCR_WRAP : Int;
+	public static var GL_DECR_WRAP : Int;
+
+	public static var GL_FRAMEBUFFER_COMPLETE : Int;
+	public static var GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT : Int;
+	public static var GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT : Int;
+	public static var GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS : Int;
+	public static var GL_FRAMEBUFFER_UNSUPPORTED : Int;
+
 	public static function glClear(bits: Int): Void;
 	public static function glGetError(): Int;
 	public static function glBindBuffer(type : Int, buffer : Int) : Void;
@@ -113,4 +141,19 @@ extern class GLES20 {
 	public static function glDepthFunc(func: Int): Void;
 	public static function glDepthMask(flag: Bool): Void;
 	public static function glCullFace(mode: Int): Void;
+
+	public static function glStencilFunc(func: Int, ref: Int,  mask: Int): Void;
+	public static function glStencilOp(fail: Int, zfail: Int, zpass: Int): Void;
+	public static function glStencilMask(mask: Int) : Void;
+	public static function glClearStencil(s: Int) : Void;
+
+	public static function glGenRenderbuffers(n : Int, buffers: NativeArray<Int>, offset : Int) : Void;
+	public static function glBindRenderbuffer(target: Int, renderBuffer: Int): Void;
+	public static function glRenderbufferStorage(target: Int, internalFormat: Int, width: Int, height: Int): Void;
+	public static function glFramebufferRenderbuffer(target: Int, attachment: Int, renderBufferTarget: Int, renderBuffer: Int): Void;
+	public static function glCheckFramebufferStatus(target: Int): Int;
+	public static function glDeleteRenderbuffers(n: Int, renderBuffers: NativeArray<Int>, offset: Int): Void;
+
+	//public static var GL_EXTENSIONS : Int;
+	//public static function glGetString(name: Int): String;
 }

--- a/Backends/Android/android/opengl/GLSurfaceView.hx
+++ b/Backends/Android/android/opengl/GLSurfaceView.hx
@@ -13,5 +13,6 @@ extern class GLSurfaceView extends View {
 	public function onResume(): Void;
 	public function setPreserveEGLContextOnPause(preserveOnPause: Bool): Void;
 	public function setEGLContextClientVersion(version: Int): Void;
+	public function setEGLConfigChooser(redSize: Int, greenSize: Int, blueSize: Int, alphaSize: Int, depthSize: Int, stencilSize: Int): Void;
 	public function setRenderer(renderer: GLSurfaceViewRenderer): Void;
 }

--- a/Backends/Android/com/ktxsoftware/kha/KhaView.hx
+++ b/Backends/Android/com/ktxsoftware/kha/KhaView.hx
@@ -16,7 +16,7 @@ class OnTouchRunner implements Runnable {
 	private var x: Single;
 	private var y: Single;
 	private var action: Int;
-	
+
 	public function new(renderer: KhaRenderer, id: Int, x: Single, y: Single, action: Int) {
 		this.renderer = renderer;
 		this.id = id;
@@ -24,7 +24,7 @@ class OnTouchRunner implements Runnable {
 		this.y = y;
 		this.action = action;
 	}
-	
+
 	public function run(): Void {
 		renderer.touch(id, Math.round(x), Math.round(y), action);
 	}
@@ -33,12 +33,12 @@ class OnTouchRunner implements Runnable {
 class OnKeyDownRunner implements Runnable {
 	private var renderer: KhaRenderer;
 	private var keyCode: Int;
-	
+
 	public function new(renderer: KhaRenderer, keyCode: Int) {
 		this.renderer = renderer;
 		this.keyCode = keyCode;
 	}
-	
+
 	public function run(): Void {
 		renderer.key(keyCode, true);
 	}
@@ -47,12 +47,12 @@ class OnKeyDownRunner implements Runnable {
 class OnKeyUpRunner implements Runnable {
 	private var renderer: KhaRenderer;
 	private var keyCode: Int;
-	
+
 	public function new(renderer: KhaRenderer, keyCode: Int) {
 		this.renderer = renderer;
 		this.keyCode = keyCode;
 	}
-	
+
 	public function run(): Void {
 		renderer.key(keyCode, false);
 	}
@@ -61,36 +61,37 @@ class OnKeyUpRunner implements Runnable {
 class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 	private var renderer: KhaRenderer;
 	private var inputManager: InputMethodManager;
-	
+
 	public function new(activity: KhaActivity) {
 		super(activity);
 		setFocusable(true);
 		setFocusableInTouchMode(true);
 		setPreserveEGLContextOnPause(true);
 		setEGLContextClientVersion(2);
+		setEGLConfigChooser(8, 8, 8, 8, 16, 8);
    		setRenderer(renderer = new KhaRenderer(activity.getApplicationContext(), this));
    		setOnTouchListener(this);
    		initInputManager(activity);
 	}
-	
+
 	@:functionCode('inputManager = (android.view.inputmethod.InputMethodManager)activity.getSystemService(android.content.Context.INPUT_METHOD_SERVICE);')
 	private function initInputManager(activity: KhaActivity): Void {
-		
+
 	}
-	
+
 	//unused
 	//@:overload public function new(context: Context) {
 	//	super(context);
 	//}
-	
+
 	public function showKeyboard(): Void {
 		inputManager.toggleSoftInputFromWindow(getApplicationWindowToken(), InputMethodManager.SHOW_IMPLICIT, 0);
 	}
-	
+
 	public function hideKeyboard(): Void {
 		inputManager.hideSoftInputFromWindow(getApplicationWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
 	}
-	
+
 	public function onTouch(view: View, event: MotionEvent): Bool {
 		var index = event.getActionIndex();
 		var maskedAction = event.getActionMasked();
@@ -102,20 +103,20 @@ class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 		action = (action == -1 && maskedAction == MotionEvent.ACTION_MOVE) ? ACTION_MOVE : action;
 		action = (action == -1 && (maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP || maskedAction == MotionEvent.ACTION_CANCEL))
 				? ACTION_UP : action;
-				
+
 		switch action {
 			case 1: //ACTION_MOVE
 				var pointerCount = event.getPointerCount();
 				for(i in 0...pointerCount) {
 					queueEvent(new OnTouchRunner(renderer, event.getPointerId(i), event.getX(i), event.getY(i), action));
 				}
-				
-			default: 
+
+			default:
 			queueEvent(new OnTouchRunner(renderer, event.getPointerId(index), event.getX(index), event.getY(index), action));
 		}
 		return true;
 	}
-	
+
 	public function onKeyDown(keyCode: Int, event: KeyEvent): Bool {
 		switch (event.getKeyCode()) {
 		case KeyEvent.KEYCODE_VOLUME_DOWN:
@@ -127,7 +128,7 @@ class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 		this.queueEvent(new OnKeyDownRunner(renderer, keyCode));
 		return true;
 	}
-	
+
 	public function onKeyUp(keyCode: Int, event: KeyEvent): Bool {
 		switch (event.getKeyCode()) {
 		case KeyEvent.KEYCODE_VOLUME_DOWN:
@@ -139,7 +140,7 @@ class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 		this.queueEvent(new OnKeyUpRunner(renderer, keyCode));
 	    return true;
 	}
-	
+
 	//public function accelerometer(x: Single, y: Single, z: Single): Void {
 	//	queueEvent(new Runnable() {
 	//		@Override
@@ -148,7 +149,7 @@ class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 	//		}
 	//	});
 	//}
-	
+
 	//public function gyro(x: Single, y: Single, z: Single): Void {
 	//	queueEvent(new Runnable() {
 	//		@Override

--- a/Backends/Android/kha/Image.hx
+++ b/Backends/Android/kha/Image.hx
@@ -4,6 +4,7 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.opengl.GLES20;
+import android.opengl.GLES11Ext;
 import android.opengl.GLUtils;
 import haxe.io.Bytes;
 import java.lang.ref.WeakReference;
@@ -16,7 +17,7 @@ import kha.graphics4.Usage;
 
 class Image implements Canvas implements Resource {
 	public static var assets: AssetManager;
-	
+
 	private var myWidth: Int;
 	private var myHeight: Int;
 	private var myRealWidth: Int;
@@ -24,12 +25,13 @@ class Image implements Canvas implements Resource {
 	private var format: TextureFormat;
 	public var tex: Int = -1;
 	public var framebuffer: Int = -1;
-	
+	private var depthStencilBuffers : NativeArray<Int>;
+
 	private var graphics1: kha.graphics1.Graphics;
 	private var graphics2: kha.graphics2.Graphics;
 	private var graphics4: kha.graphics4.Graphics;
-	
-	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool) {
+
+	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool, depthAndStencil : Bool) {
 		myWidth = width;
 		myHeight = height;
 		myRealWidth = upperPowerOfTwo(width);
@@ -38,19 +40,46 @@ class Image implements Canvas implements Resource {
 		tex = createTexture();
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, tex);
 		//Sys.gl.pixelStorei(Sys.gl.UNPACK_FLIP_Y_WEBGL, true);
-		
+
 		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
 		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
 		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
 		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
+
 		if (renderTarget) {
 			framebuffer = createFramebuffer();
 			GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, framebuffer);
 			GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, realWidth, realHeight, 0, GLES20.GL_RGBA, format == TextureFormat.RGBA128 ? GLES20.GL_FLOAT : GLES20.GL_UNSIGNED_BYTE, null);
 			GLES20.glFramebufferTexture2D(GLES20.GL_FRAMEBUFFER, GLES20.GL_COLOR_ATTACHMENT0, GLES20.GL_TEXTURE_2D, tex, 0);
+
+			if (depthAndStencil) {
+				var setupModes = [setup_oesExtension, setup_separateBuffers];
+				var succeeded = false;
+
+				for (setup in setupModes) {
+					var result = setup();
+					logFramebufferStatus(result);
+
+					switch (result) {
+						case GLES20.GL_FRAMEBUFFER_COMPLETE: {
+							succeeded = true;
+							trace('working depth/stencil combination found');
+							break;
+						}
+						default: {
+							trace('trying next setup');
+							continue;
+						}
+					}
+				}
+
+				if (!succeeded) {
+					trace('no valid depth/stencil combination found');
+				}
+			}
+
 			GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0);
-		}
-		else {
+		} else {
 			//GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, GLES20.GL_RGBA, format == TextureFormat.RGBA128 ? GLES20.GL_FLOAT : GLES20.GL_UNSIGNED_BYTE, image);
 			switch (format) {
 			case L8:
@@ -64,25 +93,95 @@ class Image implements Canvas implements Resource {
 		//Sys.gl.generateMipmap(Sys.gl.TEXTURE_2D);
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 	}
-	
+
+	function setup_oesExtension() : Int {
+		trace('GL_DEPTH_STENCIL_OES setup');
+
+		depthStencilBuffers = new NativeArray<Int>(1);
+		GLES20.glGenTextures(1, depthStencilBuffers, 0);
+
+		var dsBuffer = depthStencilBuffers[0];
+
+		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, dsBuffer);
+
+		GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
+		GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES11Ext.GL_DEPTH_STENCIL_OES, realWidth, realHeight, 0, GLES11Ext.GL_DEPTH_STENCIL_OES, GLES11Ext.GL_UNSIGNED_INT_24_8_OES, null);
+		GLES20.glFramebufferTexture2D(GLES20.GL_FRAMEBUFFER, GLES20.GL_DEPTH_ATTACHMENT, GLES20.GL_TEXTURE_2D, dsBuffer, 0);
+		GLES20.glFramebufferTexture2D(GLES20.GL_FRAMEBUFFER, GLES20.GL_STENCIL_ATTACHMENT, GLES20.GL_TEXTURE_2D, dsBuffer, 0);
+		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+
+		var result = GLES20.glCheckFramebufferStatus(GLES20.GL_FRAMEBUFFER);
+
+		if (result != GLES20.GL_FRAMEBUFFER_COMPLETE) {
+			GLES20.glDeleteRenderbuffers(depthStencilBuffers.length, depthStencilBuffers, 0);
+		}
+
+		return result;
+	}
+
+	// TODO (DK)
+	//	-doesn't fail, but doesn't work on my htc desire x -.-
+	//	-fails on galaxy s4 at work
+	function setup_separateBuffers() : Int {
+		trace('GL_DEPTH_COMPONENT16 / GL_STENCIL_INDEX8 setup');
+
+		depthStencilBuffers = new NativeArray<Int>(2);
+		GLES20.glGenRenderbuffers(2, depthStencilBuffers, 0);
+
+		var depthBuffer = depthStencilBuffers[0];
+		var stencilBuffer = depthStencilBuffers[1];
+
+		GLES20.glBindRenderbuffer(GLES20.GL_RENDERBUFFER, depthBuffer);
+		GLES20.glRenderbufferStorage(GLES20.GL_RENDERBUFFER, GLES20.GL_DEPTH_COMPONENT16, realWidth, realHeight);
+
+		GLES20.glBindRenderbuffer(GLES20.GL_RENDERBUFFER, stencilBuffer);
+		GLES20.glRenderbufferStorage(GLES20.GL_RENDERBUFFER, GLES20.GL_STENCIL_INDEX8, realWidth, realHeight);
+
+		GLES20.glFramebufferRenderbuffer(GLES20.GL_FRAMEBUFFER, GLES20.GL_DEPTH_ATTACHMENT, GLES20.GL_RENDERBUFFER, depthBuffer);
+		GLES20.glFramebufferRenderbuffer(GLES20.GL_FRAMEBUFFER, GLES20.GL_STENCIL_ATTACHMENT, GLES20.GL_RENDERBUFFER, stencilBuffer);
+
+		GLES20.glBindRenderbuffer(GLES20.GL_RENDERBUFFER, 0);
+
+		var result = GLES20.glCheckFramebufferStatus(GLES20.GL_FRAMEBUFFER);
+
+		if (result != GLES20.GL_FRAMEBUFFER_COMPLETE) {
+			GLES20.glDeleteRenderbuffers(depthStencilBuffers.length, depthStencilBuffers, 0);
+		}
+
+		return result;
+	}
+
+	function logFramebufferStatus( status : Int ) {
+		var message = switch (status) {
+			case GLES20.GL_FRAMEBUFFER_COMPLETE: 'complete';
+			case GLES20.GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT: 'incomplete attachments';
+			case GLES20.GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: 'incomplete missing attachments';
+			case GLES20.GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS: 'incomplete dimensions';
+			case GLES20.GL_FRAMEBUFFER_UNSUPPORTED: 'invalid combination of attachments';
+			default: 'unknown';
+		}
+
+		trace('framebuffer status "${message}"');
+	}
+
 	@:allow(kha.LoaderImpl)
 	private static function createFromFile(filename: String): Image {
 		try {
 			var b = BitmapFactory.decodeStream(assets.open(filename));
-			var image = new Image(b.getWidth(), b.getHeight(), TextureFormat.RGBA32, false);
+			var image = new Image(b.getWidth(), b.getHeight(), TextureFormat.RGBA32, false, false);
 			GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, image.tex);
-			
+
 			GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, image.realWidth, image.realHeight, 0, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, null);
-			
+
 			GLUtils.texSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, b, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE);
-			
+
 			//var buffer = ByteBuffer.allocateDirect(b.getWidth() * b.getHeight() * 4);
 			//b.copyPixelsToBuffer(buffer);
 			//GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, image.realWidth, image.realHeight, 0, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, buffer);
 			//GLES20.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, b.getWidth(), b.getHeight(), GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, buffer);
-			
+
 			//GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, b, 0);
-			
+
 			return image;
 		}
 		catch (ex: IOException) {
@@ -90,45 +189,45 @@ class Image implements Canvas implements Resource {
 			return null;
 		}
 	}
-	
+
 	public static function create(width: Int, height: Int, format: TextureFormat = null, usage: Usage = null, levels: Int = 1): Image {
 		if (format == null) format = TextureFormat.RGBA32;
 		if (usage == null) usage = Usage.StaticUsage;
-		return new Image(width, height, format, false);
+		return new Image(width, height, format, false, false);
 	}
-	
+
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: Bool = false, antiAliasingSamples: Int = 1): Image {
 		if (format == null) format = TextureFormat.RGBA32;
-		return new Image(width, height, format, true);
+		return new Image(width, height, format, true, depthStencil);
 	}
-	
+
 	public var g1(get, null): kha.graphics1.Graphics;
-	
+
 	private function get_g1(): kha.graphics1.Graphics {
 		if (graphics1 == null) {
 			graphics1 = new kha.graphics2.Graphics1(this);
 		}
 		return graphics1;
 	}
-		
+
 	public var g2(get, null): kha.graphics2.Graphics;
-	
+
 	private function get_g2(): kha.graphics2.Graphics {
 		if (graphics2 == null) {
 			graphics2 = new kha.graphics4.Graphics2(this);
 		}
 		return graphics2;
 	}
-	
+
 	public var g4(get, null): kha.graphics4.Graphics;
-	
+
 	private function get_g4(): kha.graphics4.Graphics {
 		if (graphics4 == null) {
 			graphics4 = new kha.android.Graphics(this);
 		}
 		return graphics4;
 	}
-	
+
 	public function unload(): Void {
 		if (tex >= 0) {
 			var textures = new NativeArray<Int>(1);
@@ -140,14 +239,18 @@ class Image implements Canvas implements Resource {
 			framebuffers[0] = framebuffer;
 			GLES20.glDeleteFramebuffers(1, framebuffers, 0);
 		}
+		if (depthStencilBuffers != null) {
+			GLES20.glDeleteRenderbuffers(depthStencilBuffers.length, depthStencilBuffers, 0);
+			depthStencilBuffers = null;
+		}
 	}
-	
+
 	private static function createFramebuffer(): Int {
 		var framebuffers = new NativeArray<Int>(1);
 		GLES20.glGenFramebuffers(1, framebuffers, 0);
 		return framebuffers[0];
 	}
-	
+
 	private static function createTexture(): Int {
 		var textures = new NativeArray<Int>(1);
 		GLES20.glGenTextures(1, textures, 0);
@@ -158,31 +261,31 @@ class Image implements Canvas implements Resource {
 		GLES20.glActiveTexture(GLES20.GL_TEXTURE0 + stage);
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, tex);
 	}
-		
+
 	public var width(get, null): Int;
-	
+
 	private function get_width(): Int {
 		return myWidth;
 	}
-	
+
 	public var height(get, null): Int;
 
 	private function get_height(): Int {
 		return myHeight;
 	}
-	
+
 	public var realWidth(get, null): Int;
-	
+
 	private function get_realWidth(): Int {
 		return myRealWidth;
 	}
-	
+
 	public var realHeight(get, null): Int;
-	
+
 	private function get_realHeight(): Int {
 		return myRealHeight;
 	}
-	
+
 	public function at(x: Int, y: Int): Int {
 		return 0;
 	}
@@ -191,18 +294,18 @@ class Image implements Canvas implements Resource {
 		//return (b.getPixel(x, y) >> 24) != 0;
 		return false;
 	}
-	
+
 	private var bytes: Bytes = null;
-	
+
 	public function lock(level: Int = 0): Bytes {
 		bytes = Bytes.alloc(format == TextureFormat.RGBA32 ? 4 * width * height : (format == TextureFormat.RGBA128 ? 16 * width * height : width * height));
 		return bytes;
 	}
-	
+
 	public function unlock(): Void {
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, tex);
 		//Sys.gl.pixelStorei(Sys.gl.UNPACK_FLIP_Y_WEBGL, true);
-		
+
 		switch (format) {
 		case L8:
 			GLES20.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, width, height, GLES20.GL_LUMINANCE, GLES20.GL_UNSIGNED_BYTE, ByteBuffer.wrap(bytes.getData()));
@@ -211,24 +314,24 @@ class Image implements Canvas implements Resource {
 		case RGBA128:
 			GLES20.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, width, height, GLES20.GL_RGBA, GLES20.GL_FLOAT, ByteBuffer.wrap(bytes.getData()));
 		}
-		
+
 		//Sys.gl.generateMipmap(Sys.gl.TEXTURE_2D);
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 		bytes = null;
 	}
-	
+
 	public static var maxSize(get, null): Int;
-	
+
 	public static function get_maxSize(): Int {
 		return 2048;
 	}
-	
+
 	public static var nonPow2Supported(get, null): Bool;
-	
+
 	public static function get_nonPow2Supported(): Bool {
 		return false;
 	}
-	
+
 	private static function upperPowerOfTwo(v: Int): Int {
 		v--;
 		v |= v >>> 1;

--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -37,7 +37,7 @@ class Graphics implements kha.graphics4.Graphics {
 	private var framebuffer: Dynamic;
 	private var indexBuffer: IndexBuffer;
 	private var renderTarget: Image;
-	
+
 	public function new(renderTarget: Image = null) {
 		this.renderTarget = renderTarget;
 		GLES20.glEnable(GLES20.GL_BLEND);
@@ -55,25 +55,25 @@ class Graphics implements kha.graphics4.Graphics {
 			GLES20.glViewport(0, 0, renderTarget.realWidth, renderTarget.realHeight);
 		}
 	}
-	
+
 	public function end(): Void {
 		/*if (GLES20.glGetError() != GLES20.GL_NO_ERROR) {
 			trace('GL Error.');
 		}*/
 	}
-	
+
 	public function flush(): Void {
-		
+
 	}
-	
+
 	public function vsynced(): Bool {
 		return true;
 	}
-	
+
 	public function refreshRate(): Int {
 		return 60;
 	}
-	
+
 	public function clear(?color: Color, ?depth: Float, ?stencil: Int): Void {
 		var clearMask: Int = 0;
 		if (color != null) {
@@ -86,14 +86,18 @@ class Graphics implements kha.graphics4.Graphics {
 		}
 		if (stencil != null) {
 			clearMask |= GLES20.GL_STENCIL_BUFFER_BIT;
+			GLES20.glClearStencil(stencil);
+
+			// (DK) see: http://stackoverflow.com/questions/29042106/android-opengl-2-0-stencil-buffer-not-working
+			GLES20.glStencilMask(0xff);
 		}
 		GLES20.glClear(clearMask);
 	}
-	
+
 	public function viewport(x: Int, y: Int, width: Int, height: Int): Void {
 		GLES20.glViewport(x, y, width, height);
 	}
-	
+
 	public function setDepthMode(write: Bool, mode: CompareMode): Void {
 		switch (mode) {
 		case Always:
@@ -123,7 +127,7 @@ class Graphics implements kha.graphics4.Graphics {
 		}
 		GLES20.glDepthMask(write);
 	}
-	
+
 	private static function getBlendFunc(op: BlendingOperation): Int {
 		switch (op) {
 		case BlendZero, Undefined:
@@ -140,7 +144,7 @@ class Graphics implements kha.graphics4.Graphics {
 			return GLES20.GL_ONE_MINUS_DST_ALPHA;
 		}
 	}
-	
+
 	public function setBlendingMode(source: BlendingOperation, destination: BlendingOperation): Void {
 		if (source == BlendOne && destination == BlendZero) {
 			GLES20.glDisable(GLES20.GL_BLEND);
@@ -150,33 +154,33 @@ class Graphics implements kha.graphics4.Graphics {
 			GLES20.glBlendFunc(getBlendFunc(source), getBlendFunc(destination));
 		}
 	}
-	
+
 	public function createVertexBuffer(vertexCount: Int, structure: VertexStructure, usage: Usage, canRead: Bool = false): kha.graphics4.VertexBuffer {
 		return new VertexBuffer(vertexCount, structure, usage);
 	}
-	
+
 	public function setVertexBuffer(vertexBuffer: kha.graphics4.VertexBuffer): Void {
 		cast(vertexBuffer, VertexBuffer).set();
 	}
-	
+
 	public function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void {
-		
+
 	}
-	
+
 	public function createIndexBuffer(indexCount: Int, usage: Usage, canRead: Bool = false): kha.graphics4.IndexBuffer {
 		return new IndexBuffer(indexCount, usage);
 	}
-	
+
 	public function setIndexBuffer(indexBuffer: kha.graphics4.IndexBuffer): Void {
 		//indicesCount = indexBuffer.count();
 		//cast(indexBuffer, IndexBuffer).set();
 		this.indexBuffer = indexBuffer;
 	}
-	
+
 	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
 		return null;
 	}
-	
+
 	public function setTexture(stage: kha.graphics4.TextureUnit, texture: kha.Image): Void {
 		if (texture == null) {
 			GLES20.glActiveTexture(GLES20.GL_TEXTURE0 + cast(stage, TextureUnit).value);
@@ -190,10 +194,10 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 
 	}
-	
+
 	public function setTextureParameters(texunit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
 		GLES20.glActiveTexture(GLES20.GL_TEXTURE0 + cast(texunit, TextureUnit).value);
-		
+
 		switch (uAddressing) {
 		case Clamp:
 			GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
@@ -202,7 +206,7 @@ class Graphics implements kha.graphics4.Graphics {
 		case Mirror:
 			GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_MIRRORED_REPEAT);
 		}
-		
+
 		switch (vAddressing) {
 		case Clamp:
 			GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
@@ -211,7 +215,7 @@ class Graphics implements kha.graphics4.Graphics {
 		case Mirror:
 			GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_MIRRORED_REPEAT);
 		}
-	
+
 		switch (minificationFilter) {
 		case PointFilter:
 			switch (mipmapFilter) {
@@ -232,7 +236,7 @@ class Graphics implements kha.graphics4.Graphics {
 				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR_MIPMAP_LINEAR);
 			}
 		}
-		
+
 		switch (magnificationFilter) {
 			case PointFilter:
 				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
@@ -240,7 +244,7 @@ class Graphics implements kha.graphics4.Graphics {
 				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
 		}
 	}
-	
+
 	public function setCullMode(mode: CullMode): Void {
 		switch (mode) {
 		case None:
@@ -255,56 +259,60 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function setPipeline(pipeline: PipelineState): Void {
+		setCullMode(pipeline.cullMode);
+		setDepthMode(pipeline.depthWrite, pipeline.depthMode);
+		setStencilParameters(pipeline.stencilMode, pipeline.stencilBothPass, pipeline.stencilDepthFail, pipeline.stencilFail, pipeline.stencilReferenceValue, pipeline.stencilReadMask, pipeline.stencilWriteMask);
+		setBlendingMode(pipeline.blendSource, pipeline.blendDestination);
 		pipeline.set();
 	}
-	
+
 	public function setBool(location: kha.graphics4.ConstantLocation, value: Bool): Void {
 		GLES20.glUniform1i(cast(location, ConstantLocation).value, value ? 1 : 0);
 	}
-	
+
 	public function setInt(location: kha.graphics4.ConstantLocation, value: Int): Void {
 		GLES20.glUniform1i(cast(location, ConstantLocation).value, value);
 	}
-	
+
 	public function setFloat(location: kha.graphics4.ConstantLocation, value: Float): Void {
 		GLES20.glUniform1f(cast(location, ConstantLocation).value, value);
 	}
-	
+
 	public function setFloat2(location: kha.graphics4.ConstantLocation, value1: Float, value2: Float): Void {
 		GLES20.glUniform2f(cast(location, ConstantLocation).value, value1, value2);
 	}
-	
+
 	public function setFloat3(location: kha.graphics4.ConstantLocation, value1: Float, value2: Float, value3: Float): Void {
 		GLES20.glUniform3f(cast(location, ConstantLocation).value, value1, value2, value3);
 	}
-	
+
 	public function setFloat4(location: kha.graphics4.ConstantLocation, value1: Float, value2: Float, value3: Float, value4: Float): Void {
 		GLES20.glUniform4f(cast(location, ConstantLocation).value, value1, value2, value3, value4);
 	}
-	
+
 	private var valuesCache = new NativeArray<Single>(128);
-	
+
 	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
 		for (i in 0...values.length) {
 			valuesCache[i] = values[i];
 		}
 		GLES20.glUniform1fv(cast(location, ConstantLocation).value, values.length, valuesCache, 0);
 	}
-	
+
 	public function setVector2(location: kha.graphics4.ConstantLocation, value: FastVector2): Void {
 		GLES20.glUniform2f(cast(location, ConstantLocation).value, value.x, value.y);
 	}
-	
+
 	public function setVector3(location: kha.graphics4.ConstantLocation, value: FastVector3): Void {
 		GLES20.glUniform3f(cast(location, ConstantLocation).value, value.x, value.y, value.z);
 	}
-	
+
 	public function setVector4(location: kha.graphics4.ConstantLocation, value: FastVector4): Void {
 		GLES20.glUniform4f(cast(location, ConstantLocation).value, value.x, value.y, value.z, value.w);
 	}
-	
+
 	private var matrixCache = new NativeArray<Single>(16);
-	
+
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
 		matrixCache[ 0] = matrix._00; matrixCache[ 1] = matrix._01; matrixCache[ 2] = matrix._02; matrixCache[ 3] = matrix._03;
 		matrixCache[ 4] = matrix._10; matrixCache[ 5] = matrix._11; matrixCache[ 6] = matrix._12; matrixCache[ 7] = matrix._13;
@@ -316,27 +324,63 @@ class Graphics implements kha.graphics4.Graphics {
 	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {
 		GLES20.glDrawElements(GLES20.GL_TRIANGLES, count == -1 ? indexBuffer.count() : count, GLES20.GL_UNSIGNED_SHORT, indexBuffer.data);
 	}
-	
+
 	public function drawIndexedVerticesInstanced(instanceCount: Int, start: Int = 0, count: Int = -1): Void {
-		
+
 	}
-	
+
 	public function instancedRenderingAvailable(): Bool {
 		return false;
 	}
-	
+
 	public function setStencilParameters(compareMode: CompareMode, bothPass: StencilAction, depthFail: StencilAction, stencilFail: StencilAction, referenceValue: Int, readMask: Int = 0xff, writeMask: Int = 0xff): Void {
-		
+		if (	compareMode == CompareMode.Always
+			&&	bothPass == StencilAction.Keep
+			&&	depthFail == StencilAction.Keep
+			&&	stencilFail == StencilAction.Keep)
+		{
+			GLES20.glDisable(GLES20.GL_STENCIL_TEST);
+		} else {
+			GLES20.glEnable(GLES20.GL_STENCIL_TEST);
+
+			var stencilFunc = switch (compareMode) {
+				case CompareMode.Always: GLES20.GL_ALWAYS;
+				case CompareMode.Equal: GLES20.GL_EQUAL;
+				case CompareMode.Greater: GLES20.GL_GREATER;
+				case CompareMode.GreaterEqual: GLES20.GL_GEQUAL;
+				case CompareMode.Less: GLES20.GL_LESS;
+				case CompareMode.LessEqual: GLES20.GL_LEQUAL;
+				case CompareMode.Never: GLES20.GL_NEVER;
+				case CompareMode.NotEqual: GLES20.GL_NOTEQUAL;
+			}
+
+			GLES20.glStencilMask(writeMask);
+			GLES20.glStencilOp(convertStencilAction(stencilFail), convertStencilAction(depthFail), convertStencilAction(bothPass));
+			GLES20.glStencilFunc(stencilFunc, referenceValue, readMask);
+		}
+	}
+
+	inline function convertStencilAction(action: StencilAction) {
+		return switch (action) {
+			case StencilAction.Decrement: GLES20.GL_DECR;
+			case StencilAction.DecrementWrap: GLES20.GL_DECR_WRAP;
+			case StencilAction.Increment: GLES20.GL_INCR;
+			case StencilAction.IncrementWrap: GLES20.GL_INCR_WRAP;
+			case StencilAction.Invert: GLES20.GL_INVERT;
+			case StencilAction.Keep: GLES20.GL_KEEP;
+			case StencilAction.Replace: GLES20.GL_REPLACE;
+			case StencilAction.Zero: GLES20.GL_ZERO;
+		}
 	}
 
 	public function scissor(x: Int, y: Int, width: Int, height: Int): Void {
-		
+
 	}
 
 	public function disableScissor(): Void {
-		
+
 	}
-	
+
 	public function renderTargetsInvertedY(): Bool {
 		return true;
 	}

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -11,15 +11,15 @@ class Image implements Canvas implements Resource {
 		if (format == null) format = TextureFormat.RGBA32;
 		if (usage == null) usage = Usage.StaticUsage;
 		if (SystemImpl.gl == null) return new CanvasImage(width, height, format, false);
-		else return new WebGLImage(width, height, format, false);
+		else return new WebGLImage(width, height, format, false, false, false);
 	}
-	
+
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: Bool = false, antiAliasingSamples: Int = 1): Image {
 		if (format == null) format = TextureFormat.RGBA32;
 		if (SystemImpl.gl == null) return new CanvasImage(width, height, format, true);
-		else return new WebGLImage(width, height, format, true);
+		else return new WebGLImage(width, height, format, true, depthStencil, depthStencil);
 	}
-	
+
 	public static function fromImage(image: ImageElement, readable: Bool): Image {
 		if (SystemImpl.gl == null) {
 			var img = new CanvasImage(image.width, image.height, TextureFormat.RGBA32, false);
@@ -28,13 +28,13 @@ class Image implements Canvas implements Resource {
 			return img;
 		}
 		else {
-			var img = new WebGLImage(image.width, image.height, TextureFormat.RGBA32, false);
+			var img = new WebGLImage(image.width, image.height, TextureFormat.RGBA32, false, false, false);
 			img.image = image;
 			img.createTexture();
 			return img;
 		}
 	}
-	
+
 	public static function fromVideo(video: kha.js.Video): Image {
 		if (SystemImpl.gl == null) {
 			var img = new CanvasImage(video.element.videoWidth, video.element.videoHeight, TextureFormat.RGBA32, false);
@@ -43,25 +43,25 @@ class Image implements Canvas implements Resource {
 			return img;
 		}
 		else {
-			var img = new WebGLImage(video.element.videoWidth, video.element.videoHeight, TextureFormat.RGBA32, false);
+			var img = new WebGLImage(video.element.videoWidth, video.element.videoHeight, TextureFormat.RGBA32, false, false, false);
 			img.video = video.element;
 			img.createTexture();
 			return img;
 		}
 	}
-	
+
 	public static var maxSize(get, null): Int;
-	
+
 	public static function get_maxSize(): Int {
 		return SystemImpl.gl == null ? 1024 * 8 : SystemImpl.gl.getParameter(GL.MAX_TEXTURE_SIZE);
 	}
-	
+
 	public static var nonPow2Supported(get, null): Bool;
-	
+
 	public static function get_nonPow2Supported(): Bool {
 		return SystemImpl.gl != null;
 	}
-	
+
 	public function isOpaque(x: Int, y: Int): Bool { return false; }
 	public function at(x: Int, y: Int): Color { return Color.Black; }
 	public function unload(): Void { }

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -13,10 +13,10 @@ import kha.js.graphics4.Graphics;
 class WebGLImage extends Image {
 	public var image: Dynamic;
 	public var video: VideoElement;
-	
+
 	private static var context: Dynamic;
 	private var data: Dynamic;
-	
+
 	private var myWidth: Int;
 	private var myHeight: Int;
 	private var format: TextureFormat;
@@ -24,11 +24,14 @@ class WebGLImage extends Image {
 	public var frameBuffer: Dynamic;
 	public var renderBuffer: Dynamic;
 	public var texture: Dynamic;
-	
+
 	private var graphics1: kha.graphics1.Graphics;
 	private var graphics2: kha.graphics2.Graphics;
 	private var graphics4: kha.graphics4.Graphics;
-	
+
+	private var useDepthBuffer : Bool;
+	private var useStencilBuffer : Bool;
+
 	public static function init() {
 		var canvas: Dynamic = Browser.document.createElement("canvas");
 		if (canvas != null) {
@@ -38,62 +41,64 @@ class WebGLImage extends Image {
 			context.globalCompositeOperation = "copy";
 		}
 	}
-	
-	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool) {
+
+	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool, useDepthBuffer: Bool, useStencilBuffer: Bool) {
 		myWidth = width;
 		myHeight = height;
 		this.format = format;
 		this.renderTarget = renderTarget;
 		image = null;
 		video = null;
+		this.useStencilBuffer = useStencilBuffer;
+		this.useDepthBuffer = useDepthBuffer;
 		if (renderTarget) createTexture();
 	}
-	
+
 	override private function get_g1(): kha.graphics1.Graphics {
 		if (graphics1 == null) {
 			graphics1 = new kha.graphics2.Graphics1(this);
 		}
 		return graphics1;
 	}
-	
+
 	override private function get_g2(): kha.graphics2.Graphics {
 		if (graphics2 == null) {
 			graphics2 = new kha.js.graphics4.Graphics2(this);
 		}
 		return graphics2;
 	}
-		
+
 	override private function get_g4(): kha.graphics4.Graphics {
 		if (graphics4 == null) {
 			graphics4 = new Graphics(this);
 		}
 		return graphics4;
 	}
-	
+
 	override private function get_width(): Int {
 		return myWidth;
 	}
-	
+
 	override private function get_height(): Int {
 		return myHeight;
 	}
-	
+
 	override private function get_realWidth(): Int {
 		return myWidth;
 	}
-	
+
 	override private function get_realHeight(): Int {
 		return myHeight;
 	}
-	
+
 	override public function isOpaque(x: Int, y: Int): Bool {
 		if (data == null) {
 			if (context == null) return true;
 			else createImageData();
 		}
-		return (data.data[y * Std.int(image.width) * 4 + x * 4 + 3] != 0);		
+		return (data.data[y * Std.int(image.width) * 4 + x * 4 + 3] != 0);
 	}
-	
+
 	override public function at(x: Int, y: Int): Color {
 		if (data == null) {
 			if (context == null) return Color.Black;
@@ -101,7 +106,7 @@ class WebGLImage extends Image {
 		}
 		return Color.fromValue(data.data[y * Std.int(image.width) * 4 + x * 4 + 0]);
 	}
-	
+
 	function createImageData() {
 		context.strokeStyle = "rgba(0,0,0,0)";
 		context.fillStyle = "rgba(0,0,0,0)";
@@ -109,7 +114,7 @@ class WebGLImage extends Image {
 		context.drawImage(image, 0, 0, image.width, image.height, 0, 0, image.width, image.height);
 		data = context.getImageData(0, 0, image.width, image.height);
 	}
-	
+
 	private static function upperPowerOfTwo(v: Int): Int {
 		v--;
 		v |= v >>> 1;
@@ -120,14 +125,14 @@ class WebGLImage extends Image {
 		v++;
 		return v;
 	}
-	
+
 	public function createTexture(): Void {
 		if (SystemImpl.gl == null) return;
 		texture = SystemImpl.gl.createTexture();
 		//texture.image = image;
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, texture);
 		//Sys.gl.pixelStorei(Sys.gl.UNPACK_FLIP_Y_WEBGL, true);
-		
+
 		SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
 		SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
 		SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
@@ -137,13 +142,28 @@ class WebGLImage extends Image {
 			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 			SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, realWidth, realHeight, 0, GL.RGBA, format == TextureFormat.RGBA128 ? GL.FLOAT : GL.UNSIGNED_BYTE, null);
 			SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
-			
-			// For depth tests
-			renderBuffer = SystemImpl.gl.createRenderbuffer();
-			SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
-			SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, realWidth, realHeight);
-			SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
-			
+
+			if (useDepthBuffer && useStencilBuffer) {
+				renderBuffer = SystemImpl.gl.createRenderbuffer();
+				SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
+				SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_STENCIL, realWidth, realHeight);
+				SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
+			} else if (useDepthBuffer) {
+				// For depth tests
+				renderBuffer = SystemImpl.gl.createRenderbuffer();
+				SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
+				SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, realWidth, realHeight);
+				SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
+			} else {
+				// (DK) this was always executed, so we leave it in as default to not break existing code?
+
+				// For depth tests
+				renderBuffer = SystemImpl.gl.createRenderbuffer();
+				SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
+				SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, realWidth, realHeight);
+				SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
+			}
+
 			SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, null);
 			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, null);
 		}
@@ -152,36 +172,36 @@ class WebGLImage extends Image {
 		//Sys.gl.generateMipmap(Sys.gl.TEXTURE_2D);
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, null);
 	}
-	
+
 	public function set(stage: Int): Void {
 		SystemImpl.gl.activeTexture(GL.TEXTURE0 + stage);
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, texture);
 		if (video != null) SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, video);
 	}
-	
+
 	public var bytes: Bytes;
-	
+
 	override public function lock(level: Int = 0): Bytes {
 		bytes = Bytes.alloc(format == TextureFormat.RGBA32 ? 4 * width * height : (format == TextureFormat.RGBA128 ? 16 * width * height : width * height));
 		return bytes;
 	}
-	
+
 	override public function unlock(): Void {
 		if (SystemImpl.gl != null) {
 			texture = SystemImpl.gl.createTexture();
 			//texture.image = image;
 			SystemImpl.gl.bindTexture(GL.TEXTURE_2D, texture);
 			//Sys.gl.pixelStorei(Sys.gl.UNPACK_FLIP_Y_WEBGL, true);
-			
+
 			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
-			
+
 			switch (format) {
 			case L8:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, width, height, 0, GL.LUMINANCE, GL.UNSIGNED_BYTE, new Uint8Array(bytes.getData()));
-				
+
 				if (SystemImpl.gl.getError() == 1282) { // no LUMINANCE support in IE11
 					var rgbaBytes = Bytes.alloc(width * height * 4);
 					for (y in 0...height) for (x in 0...width) {
@@ -198,14 +218,14 @@ class WebGLImage extends Image {
 			case RGBA128:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.FLOAT, new Uint8Array(bytes.getData()));
 			}
-			
+
 			//Sys.gl.generateMipmap(Sys.gl.TEXTURE_2D);
 			SystemImpl.gl.bindTexture(GL.TEXTURE_2D, null);
 			bytes = null;
 		}
 	}
-	
+
 	override public function unload(): Void {
-		
+
 	}
 }


### PR DESCRIPTION
Hi Robert,

this PR adds support for depth/stencil buffers on android.
I'm not quite sure it's the best way to implement it. I tried using a separate attached stencil/depth buffer, but that fails on the s4 and succeeded but didn't work on my htc. Now i use the GLES1.1 GL_DEPTH_STENCIL_OES extension and it's working on all devices i have access to so far (HTC Desire X, S3, S4, HUAWEI Ascend something).

Edit: Oh it seems that the 'HTML5 stencil support' commit got somehow added as well (i'm still very much a noob in using git; I thought a pull request is just for a specific commit. I wanted to create a separate PR for it so they stay small and easier to merge).