### PR TITLE
Refactoring: kha.Image.createRenderTarget() uses the DepthStencilFormat enum now instead of a bool

### DIFF
--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -2,6 +2,7 @@ package kha;
 
 import flash.utils.ByteArray;
 import haxe.io.Bytes;
+import kha.DepthStencilFormat;
 import kha.graphics4.TextureFormat;
 import kha.graphics4.Usage;
 import flash.display.Bitmap;
@@ -18,25 +19,25 @@ class Image implements Canvas implements Resource {
 	private var texWidth: Int;
 	private var texHeight: Int;
 	private var format: TextureFormat;
-	private var depthStencil: Bool;
-	
+	private var depthStencil: DepthStencilFormat;
+
 	private var data: BitmapData;
 	private var bytes: Bytes;
 	private var readable: Bool;
-	
+
 	private var graphics1: kha.graphics1.Graphics;
 	private var graphics2: kha.graphics2.Graphics;
 	private var graphics4: kha.graphics4.Graphics;
-	
+
 	public static function create(width: Int, height: Int, format: TextureFormat = null, usage: Usage = null, levels: Int = 1): Image {
-		return new Image(width, height, format == null ? TextureFormat.RGBA32 : format, false, false, usage == Usage.ReadableUsage);
+		return new Image(width, height, format == null ? TextureFormat.RGBA32 : format, false, NoDepthAndStencil, usage == Usage.ReadableUsage);
 	}
-	
-	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: Bool = false, antiAliasingSamples: Int = 1): Image {
+
+	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = DepthStencilFormat.NoDepthAndStencil, antiAliasingSamples: Int = 1): Image {
 		return new Image(width, height, format == null ? TextureFormat.RGBA32 : format, true, depthStencil, false);
 	}
-	
-	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool, depthStencil: Bool, readable: Bool) {
+
+	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool, depthStencil: DepthStencilFormat, readable: Bool) {
 		myWidth = width;
 		myHeight = height;
 		texWidth = upperPowerOfTwo(Std.int(myWidth));
@@ -46,109 +47,113 @@ class Image implements Canvas implements Resource {
 		this.readable = readable;
 		tex = SystemImpl.context.createTexture(texWidth, texHeight, format == TextureFormat.RGBA128 ? Context3DTextureFormat.RGBA_HALF_FLOAT : Context3DTextureFormat.BGRA, renderTarget);
 	}
-	
+
 	public static function fromBitmap(image: DisplayObject, readable: Bool): Image {
 		var bitmap = cast(image, Bitmap);
 		return fromBitmapData(bitmap.bitmapData, readable);
 	}
-	
+
 	public static function fromBitmapData(image: BitmapData, readable: Bool): Image {
-		var texture = new Image(Std.int(image.width), Std.int(image.height), TextureFormat.RGBA32, false, false, readable);
+		var texture = new Image(Std.int(image.width), Std.int(image.height), TextureFormat.RGBA32, false, NoDepthAndStencil, readable);
 		texture.uploadBitmap(image, readable);
 		return texture;
 	}
-	
+
 	public function uploadBitmap(bitmap: BitmapData, readable: Bool): Void {
 		if (readable) data = bitmap;
 		tex.uploadFromBitmapData(bitmap, 0);
 	}
-	
+
 	public var g1(get, null): kha.graphics1.Graphics;
-	
+
 	private function get_g1(): kha.graphics1.Graphics {
 		if (graphics1 == null) {
 			graphics1 = new kha.graphics2.Graphics1(this);
 		}
 		return graphics1;
 	}
-	
+
 	public var g2(get, null): kha.graphics2.Graphics;
-	
+
 	private function get_g2(): kha.graphics2.Graphics {
 		if (graphics2 == null) {
 			graphics2 = new kha.flash.graphics4.Graphics2(this);
 		}
 		return graphics2;
 	}
-	
+
 	public var g4(get, null): kha.graphics4.Graphics;
-	
+
 	private function get_g4(): kha.graphics4.Graphics {
 		if (graphics4 == null) {
 			graphics4 = new kha.flash.graphics4.Graphics(this);
 		}
 		return graphics4;
 	}
-	
+
 	public static var maxSize(get, null): Int;
-	
+
 	public static function get_maxSize(): Int {
 		return 2048;
 	}
-	
+
 	public static var nonPow2Supported(get, null): Bool;
-	
+
 	public static function get_nonPow2Supported(): Bool {
 		return false;
 	}
-	
+
 	public var width(get, null): Int;
 	public var height(get, null): Int;
-	
+
 	private function get_width(): Int {
 		return Std.int(myWidth);
 	}
-	
+
 	private function get_height(): Int {
 		return Std.int(myHeight);
 	}
-	
+
 	public var realWidth(get, null): Int;
 	public var realHeight(get, null): Int;
-	
+
 	private function get_realWidth(): Int {
 		return texWidth;
 	}
-	
+
 	private function get_realHeight(): Int {
 		return texHeight;
 	}
-	
+
 	public function unload(): Void {
 		if (tex != null) {
 			tex.dispose();
 			tex = null;
 		}
 	}
-	
+
 	public function isOpaque(x: Int, y: Int): Bool {
 		if (data != null) return (data.getPixel32(x, y) >> 24 & 0xFF) != 0;
 		if (bytes != null) return bytes.get(y * texWidth * 4 + x * 4 + 3) != 0;
 		return true;
 	}
-	
+
 	public inline function at(x: Int, y: Int): Color {
 		return Color.fromValue(data.getPixel32(x, y));
 	}
-	
+
 	public function getFlashTexture(): Texture {
 		return tex;
 	}
-	
-	public function hasDepthStencil(): Bool {
+
+	//public function hasDepthStencil(): Bool {
+		//return depthStencil;
+	//}
+
+	public function depthStencilFormat(): DepthStencilFormat {
 		return depthStencil;
 	}
-	
+
 	private static function upperPowerOfTwo(v: Int): Int {
 		v--;
 		v |= v >>> 1;
@@ -159,7 +164,7 @@ class Image implements Canvas implements Resource {
 		v++;
 		return v;
 	}
-	
+
 	public function lock(level: Int = 0): Bytes {
 		if (bytes == null) {
 			switch (format) {
@@ -173,7 +178,7 @@ class Image implements Canvas implements Resource {
 		}
 		return bytes;
 	}
-	
+
 	public function unlock(): Void {
 		switch (format) {
 			case RGBA32:
@@ -202,7 +207,7 @@ class Image implements Canvas implements Resource {
 				}
 				tex.uploadFromByteArray(rgbaBytes.getData(), 0);
 		}
-		
+
 		if (!readable) bytes = null;
 	}
 }

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -18,6 +18,7 @@ import flash.geom.Matrix3D;
 import flash.utils.ByteArray;
 import flash.Vector;
 import kha.Blob;
+import kha.DepthStencilFormat;
 import kha.graphics4.BlendingOperation;
 import kha.graphics4.CompareMode;
 import kha.graphics4.CubeMap;
@@ -50,27 +51,27 @@ class Graphics implements kha.graphics4.Graphics {
 		context.setBlendFactors(Context3DBlendFactor.SOURCE_ALPHA, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA);
 		Graphics.context = context;
 	}
-	
+
 	public function new(target: Image = null) {
 		this.target = target;
 	}
-	
+
 	public function flush(): Void {
-		
+
 	}
-	
+
 	public function init(?backbufferFormat: TextureFormat, antiAliasingSamples: Int = 1): Void {
-		
+
 	}
-	
+
 	public function vsynced(): Bool {
 		return true;
 	}
-	
+
 	public function refreshRate(): Int {
 		return Std.int(flash.Lib.current.stage.frameRate);
 	}
-	
+
 	public function clear(?color: Color, ?depth: Float, ?stencil: Int): Void {
 		var mask: UInt = 0;
 		if (color != null) mask |= Context3DClearMask.COLOR;
@@ -84,13 +85,13 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function viewport(x : Int, y : Int, width : Int, height : Int): Void{
-		//TODO better access to stage3d 
+		//TODO better access to stage3d
 		var stage3D = flash.Lib.current.stage.stage3Ds[0];
 		stage3D.x = x;
 		stage3D.y = y;
-		context.configureBackBuffer(width,height,0,false); 
+		context.configureBackBuffer(width,height,0,false);
 	}
-	
+
 	public function setCullMode(mode: CullMode): Void {
 		switch (mode) {
 		case Clockwise:
@@ -101,7 +102,7 @@ class Graphics implements kha.graphics4.Graphics {
 			context.setCulling(Context3DTriangleFace.NONE);
 		}
 	}
-	
+
 	private function getCompareMode(mode: CompareMode): Context3DCompareMode {
 		switch (mode) {
 		case Always:
@@ -126,11 +127,11 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setDepthMode(write: Bool, mode: CompareMode): Void {
 		context.setDepthTest(write, getCompareMode(mode));
 	}
-	
+
 	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
 		return null;
 	}
-	
+
 	private function getStencilAction(action: StencilAction): Context3DStencilAction {
 		switch (action) {
 		case Keep:
@@ -151,7 +152,7 @@ class Graphics implements kha.graphics4.Graphics {
 			return Context3DStencilAction.DECREMENT_WRAP;
 		}
 	}
-	
+
 	public function setStencilParameters(compareMode: CompareMode, bothPass: StencilAction, depthFail: StencilAction, stencilFail: StencilAction, referenceValue: Int, readMask: Int = 0xff, writeMask: Int = 0xff): Void {
 		context.setStencilReferenceValue(referenceValue, readMask, writeMask);
 		context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK, getCompareMode(compareMode), getStencilAction(bothPass), getStencilAction(depthFail), getStencilAction(stencilFail));
@@ -162,9 +163,9 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function disableScissor(): Void {
-		
+
 	}
-	
+
 	private function getWrapMode(addressing: TextureAddressing): Context3DWrapMode {
 		switch (addressing) {
 		case Clamp:
@@ -173,7 +174,7 @@ class Graphics implements kha.graphics4.Graphics {
 			return Context3DWrapMode.REPEAT;
 		}
 	}
-	
+
 	private function getFilter(filter: TextureFilter): Context3DTextureFilter {
 		switch (filter) {
 		case PointFilter:
@@ -182,7 +183,7 @@ class Graphics implements kha.graphics4.Graphics {
 			return Context3DTextureFilter.LINEAR;
 		}
 	}
-	
+
 	private function getMipFilter(mipFilter: MipMapFilter): Context3DMipFilter {
 		switch (mipFilter) {
 		case NoMipFilter:
@@ -193,12 +194,12 @@ class Graphics implements kha.graphics4.Graphics {
 			return Context3DMipFilter.MIPLINEAR;
 		}
 	}
-	
+
 	// Flash only supports one texture addressing and filtering mode - we use the v and mag values here
 	public function setTextureParameters(texunit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
 		context.setSamplerStateAt(cast(texunit, TextureUnit).unit, getWrapMode(vAddressing), getFilter(magnificationFilter), getMipFilter(mipmapFilter));
 	}
-	
+
 	private function getBlendFactor(op: BlendingOperation): Context3DBlendFactor {
 		switch (op) {
 			case BlendZero, Undefined:
@@ -223,27 +224,27 @@ class Graphics implements kha.graphics4.Graphics {
 	//public function createVertexBuffer(vertexCount: Int, structure: kha.graphics4.VertexStructure, usage: Usage, canRead: Bool = false): kha.graphics4.VertexBuffer {
 	//	return new VertexBuffer(vertexCount, structure, usage);
 	//}
-	
+
 	public function setVertexBuffer(vertexBuffer: kha.graphics4.VertexBuffer): Void {
 		vertexBuffer.set();
 	}
-	
+
 	public function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void {
-		
+
 	}
-	
+
 	//public function createIndexBuffer(indexCount: Int, usage: Usage, canRead: Bool = false): kha.graphics4.IndexBuffer {
 	//	return new IndexBuffer(indexCount, usage);
 	//}
-	
+
 	public function setIndexBuffer(indexBuffer: kha.graphics4.IndexBuffer): Void {
 		indexBuffer.set();
 	}
-	
+
 	//public function createProgram(): kha.graphics4.Program {
 	//	return new Program();
 	//}
-	
+
 	public function setPipeline(pipe: PipelineState): Void {
 		setCullMode(pipe.cullMode);
 		setDepthMode(pipe.depthWrite, pipe.depthMode);
@@ -251,23 +252,23 @@ class Graphics implements kha.graphics4.Graphics {
 		setBlendingMode(pipe.blendSource, pipe.blendDestination);
 		pipe.set();
 	}
-	
+
 	//public function createTexture(width: Int, height: Int, format: TextureFormat, usage: Usage, canRead: Bool = false, levels: Int = 1): Texture {
 	//	return new Image(width, height, format, false, false, canRead);
 	//}
-	
+
 	//public function createRenderTargetTexture(width: Int, height: Int, format: TextureFormat, depthStencil: Bool, antiAliasingSamples: Int = 1): Texture {
 	//	return new Image(width, height, format, true, depthStencil, false);
 	//}
-	
+
 	public function maxTextureSize(): Int {
 		return 2048;
 	}
-	
+
 	public function supportsNonPow2Textures(): Bool {
 		return false;
 	}
-	
+
 	public function setTexture(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
 		context.setTextureAt(cast(unit, TextureUnit).unit, texture == null ? null : cast(texture, Image).getFlashTexture());
 	}
@@ -275,19 +276,19 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 
 	}
-		
+
 	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {
 		context.drawTriangles(IndexBuffer.current.indexBuffer, start, count >= 0 ? Std.int(count / 3) : count);
 	}
-	
+
 	public function drawIndexedVerticesInstanced(instanceCount: Int, start: Int = 0, count: Int = -1): Void {
-		
+
 	}
-	
+
 	public function instancedRenderingAvailable(): Bool {
 		return false;
 	}
-	
+
 	public function createVertexShader(source: Blob): kha.graphics4.VertexShader {
 		return new VertexShader(source);
 	}
@@ -295,14 +296,14 @@ class Graphics implements kha.graphics4.Graphics {
 	public function createFragmentShader(source: Blob): kha.graphics4.FragmentShader {
 		return new FragmentShader(source);
 	}
-	
+
 	public function setBool(location: kha.graphics4.ConstantLocation, value: Bool): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
 		vec[0] = value ? 1 : 0;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setInt(location: kha.graphics4.ConstantLocation, value: Int): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -316,7 +317,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[0] = value;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setFloat2(location: kha.graphics4.ConstantLocation, value1: FastFloat, value2: FastFloat): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -324,7 +325,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[1] = value2;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setFloat3(location: kha.graphics4.ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -333,7 +334,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[2] = value3;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setFloat4(location: kha.graphics4.ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -343,7 +344,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[3] = value4;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setVector2(location: kha.graphics4.ConstantLocation, value: FastVector2): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -351,7 +352,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[1] = value.y;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setVector3(location: kha.graphics4.ConstantLocation, value: FastVector3): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -360,7 +361,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[2] = value.z;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setVector4(location: kha.graphics4.ConstantLocation, value: FastVector4): Void {
 		var flashLocation = cast(location, ConstantLocation);
 		var vec = new Vector<Float>(4);
@@ -370,7 +371,7 @@ class Graphics implements kha.graphics4.Graphics {
 		vec[3] = value.w;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vec);
 	}
-	
+
 	public function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
 		var projection = new Matrix3D();
 		var vec = new Vector<Float>(16);
@@ -382,30 +383,50 @@ class Graphics implements kha.graphics4.Graphics {
 		var flashLocation = cast(location, ConstantLocation);
 		context.setProgramConstantsFromMatrix(flashLocation.type, flashLocation.value, projection, true);
 	}
-	
+
 	public function setFloats(location: kha.graphics4.ConstantLocation, values: haxe.ds.Vector<FastFloat>): Void {
 		var flashLocation: ConstantLocation = cast location;
 		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, values.toData());
 	}
-	
+
 	//public function renderToBackbuffer(): Void {
 	//	context.setRenderToBackBuffer();
 	//}
-	
+
 	//public function renderToTexture(texture: Texture): Void {
 	//	context.setRenderToTexture(cast(texture, Image).getFlashTexture(), cast(texture, Image).hasDepthStencil());
 	//}
-	
+
 	public function renderTargetsInvertedY(): Bool {
 		return false;
 	}
-	
+
 	public function begin(additionalRenderTargets: Array<Canvas> = null): Void {
 		if (target == null) context.setRenderToBackBuffer();
-		else context.setRenderToTexture(target.getFlashTexture(), target.hasDepthStencil());
+		else context.setRenderToTexture(target.getFlashTexture(), enableDepthStencil(target.depthStencilFormat()));
 	}
-	
+
+	function enableDepthStencil( format : DepthStencilFormat ) : Bool {
+		return switch (format) {
+			case NoDepthAndStencil: false;
+			case DepthOnly: true;
+			case DepthAutoStencilAuto: true;
+			case Depth24Stencil8: {
+				#if debug
+				trace('DepthStencilFormat "Depth24Stencil8" is not supported, using target defaults');
+				#end
+				true;
+			}
+			case Depth32Stencil8: {
+				#if debug
+				trace('DepthStencilFormat "Depth32Stencil8" is not supported, using target defaults');
+				#end
+				true;
+			}
+		}
+	}
+
 	public function end(): Void {
-		
+
 	}
 }

--- a/Backends/Flash/kha/flash/graphics4/Graphics2.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics2.hx
@@ -10,23 +10,23 @@ import kha.graphics4.TextureFormat;
 class Graphics2 extends kha.graphics4.Graphics2 {
 	private var videoBitmap: BitmapData;
 	private var videoImage: Image;
-	
+
 	public function new(canvas: Canvas) {
 		super(canvas);
 		videoBitmap = new BitmapData(canvas.width, canvas.height, true, 0xffffff);
-		videoImage = new Image(canvas.width, canvas.height, TextureFormat.RGBA32, false, false, false);
+		videoImage = new Image(canvas.width, canvas.height, TextureFormat.RGBA32, false, DepthStencilFormat.NoDepthAndStencil, false);
 	}
 
 	override public function drawVideoInternal(video: kha.Video, x: Float, y: Float, width: Float, height: Float): Void {
 		/*flushBuffers();
-		
+
 		var stageVideo = new flash.media.Video(Std.int(width), Std.int(height));
 		stageVideo.attachNetStream(cast(video, Video).stream);
-				
+
 		textBitmap.fillRect(new Rectangle(0, 0, textBitmap.width, textBitmap.height), 0xffffff);
 		textBitmap.draw(stageVideo);
 		textTexture.uploadFromBitmapData(textBitmap, 0);
-		
+
 		var dx = x;
 		var dy = y;
 		var dw = textField.width;
@@ -36,17 +36,17 @@ class Graphics2 extends kha.graphics4.Graphics2 {
 		var v1 = 0.0;
 		var v2 = 1.0;
 		var offset = 0;
-		
+
 		vertices[offset +  0] = tx + dx;      vertices[offset +  1] = ty + dy;      vertices[offset +  2] = 1; vertices[offset +  3] = u1; vertices[offset +  4] = v1;
 		vertices[offset +  5] = tx + dx + dw; vertices[offset +  6] = ty + dy;      vertices[offset +  7] = 1; vertices[offset +  8] = u2; vertices[offset +  9] = v1;
 		vertices[offset + 10] = tx + dx;      vertices[offset + 11] = ty + dy + dh; vertices[offset + 12] = 1; vertices[offset + 13] = u1; vertices[offset + 14] = v2;
 		vertices[offset + 15] = tx + dx + dw; vertices[offset + 16] = ty + dy + dh; vertices[offset + 17] = 1; vertices[offset + 18] = u2; vertices[offset + 19] = v2;
-		
+
 		context.setTextureAt(0, textTexture);
 		vertexBuffer.uploadFromVector(vertices, 0, 4 * 1);
 		context.drawTriangles(indexBuffer, 0, 2 * 1);
 		*/
-		
+
 		var stageVideo = new flash.media.Video(Std.int(width), Std.int(height));
 		stageVideo.attachNetStream(cast(video, Video).stream);
 		videoBitmap.fillRect(new Rectangle(0, 0, width, height), 0xffffff);

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -11,13 +11,13 @@ class Image implements Canvas implements Resource {
 		if (format == null) format = TextureFormat.RGBA32;
 		if (usage == null) usage = Usage.StaticUsage;
 		if (SystemImpl.gl == null) return new CanvasImage(width, height, format, false);
-		else return new WebGLImage(width, height, format, false, false, false);
+		else return new WebGLImage(width, height, format, false, DepthStencilFormat.NoDepthAndStencil);
 	}
 
-	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: Bool = false, antiAliasingSamples: Int = 1): Image {
+	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = DepthStencilFormat.NoDepthAndStencil, antiAliasingSamples: Int = 1): Image {
 		if (format == null) format = TextureFormat.RGBA32;
 		if (SystemImpl.gl == null) return new CanvasImage(width, height, format, true);
-		else return new WebGLImage(width, height, format, true, depthStencil, depthStencil);
+		else return new WebGLImage(width, height, format, true, depthStencil);
 	}
 
 	public static function fromImage(image: ImageElement, readable: Bool): Image {
@@ -28,7 +28,7 @@ class Image implements Canvas implements Resource {
 			return img;
 		}
 		else {
-			var img = new WebGLImage(image.width, image.height, TextureFormat.RGBA32, false, false, false);
+			var img = new WebGLImage(image.width, image.height, TextureFormat.RGBA32, false, DepthStencilFormat.NoDepthAndStencil);
 			img.image = image;
 			img.createTexture();
 			return img;
@@ -43,7 +43,7 @@ class Image implements Canvas implements Resource {
 			return img;
 		}
 		else {
-			var img = new WebGLImage(video.element.videoWidth, video.element.videoHeight, TextureFormat.RGBA32, false, false, false);
+			var img = new WebGLImage(video.element.videoWidth, video.element.videoHeight, TextureFormat.RGBA32, false, DepthStencilFormat.NoDepthAndStencil);
 			img.video = video.element;
 			img.createTexture();
 			return img;

--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -14,7 +14,7 @@ import kha.graphics4.Usage;
 class Image implements Canvas implements Resource {
 	private var format: TextureFormat;
 	private var readable: Bool;
-	
+
 	private var graphics1: kha.graphics1.Graphics;
 	private var graphics2: kha.graphics2.Graphics;
 	private var graphics4: kha.graphics4.Graphics;
@@ -25,15 +25,15 @@ class Image implements Canvas implements Resource {
 		image.initVideo(cast(video, kha.kore.Video));
 		return image;
 	}
-	
+
 	public static function create(width: Int, height: Int, format: TextureFormat = null, usage: Usage = null, levels: Int = 1): Image {
-		return create2(width, height, format == null ? TextureFormat.RGBA32 : format, false, false, false);
+		return create2(width, height, format == null ? TextureFormat.RGBA32 : format, false, false, NoDepthAndStencil);
 	}
-	
-	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: Bool = false, antiAliasingSamples: Int = 1): Image {
+
+	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = NoDepthAndStencil, antiAliasingSamples: Int = 1): Image {
 		return create2(width, height, format == null ? TextureFormat.RGBA32 : format, false, true, depthStencil);
 	}
-	
+
 	private function new(readable: Bool) {
 		this.readable = readable;
 	}
@@ -48,108 +48,128 @@ class Image implements Canvas implements Resource {
 			return 0;
 		}
 	}
-	
-	public static function create2(width: Int, height: Int, format: TextureFormat, readable: Bool, renderTarget: Bool, depthBuffer: Bool): Image {
+
+	private static function getDepthBufferBits(depthAndStencil: DepthStencilFormat): Int {
+		return switch (depthAndStencil) {
+			case NoDepthAndStencil: -1;
+			case DepthOnly: 24;
+			case DepthAutoStencilAuto: 24;
+			case Depth24Stencil8: 24;
+			case Depth32Stencil8: 32;
+		}
+	}
+
+	private static function getStencilBufferBits(depthAndStencil: DepthStencilFormat): Int {
+		return switch (depthAndStencil) {
+			case NoDepthAndStencil: -1;
+			case DepthOnly: -1;
+			case DepthAutoStencilAuto: 8;
+			case Depth24Stencil8: 8;
+			case Depth32Stencil8: 8;
+		}
+	}
+
+	public static function create2(width: Int, height: Int, format: TextureFormat, readable: Bool, renderTarget: Bool, depthStencil: DepthStencilFormat): Image {
 		var image = new Image(readable);
 		image.format = format;
-		if (renderTarget) image.initRenderTarget(width, height, getRenderTargetFormat(format), depthBuffer);
+		if (renderTarget) image.initRenderTarget(width, height, getDepthBufferBits(depthStencil), getRenderTargetFormat(format), getStencilBufferBits(depthStencil));
 		else image.init(width, height, format == TextureFormat.RGBA32 ? 0 : 1);
 		return image;
 	}
-	
-	@:functionCode('renderTarget = new Kore::RenderTarget(width, height, depthBuffer, false, (Kore::RenderTargetFormat)format); texture = nullptr;')
-	private function initRenderTarget(width: Int, height: Int, format: Int, depthBuffer: Bool): Void {
-		
+
+	@:functionCode('renderTarget = new Kore::RenderTarget(width, height, depthBufferBits, false, (Kore::RenderTargetFormat)format, stencilBufferBits); texture = nullptr;')
+	private function initRenderTarget(width: Int, height: Int, depthBufferBits: Int, format: Int, stencilBufferBits: Int): Void {
+
 	}
-	
+
 	@:functionCode('texture = new Kore::Texture(width, height, (Kore::Image::Format)format, readable); renderTarget = nullptr;')
 	private function init(width: Int, height: Int, format: Int): Void {
-		
+
 	}
 
 	@:functionCode('texture = video->video->currentImage(); renderTarget = nullptr;')
 	private function initVideo(video: kha.kore.Video): Void {
 
 	}
-	
+
 	public static function fromFile(filename: String, readable: Bool): Image {
 		var image = new Image(readable);
 		image.format = TextureFormat.RGBA32;
 		image.initFromFile(filename);
 		return image;
 	}
-	
+
 	@:functionCode('texture = new Kore::Texture(filename.c_str(), readable);')
 	private function initFromFile(filename: String): Void {
-		
+
 	}
-	
+
 	public var g1(get, null): kha.graphics1.Graphics;
-	
+
 	private function get_g1(): kha.graphics1.Graphics {
 		if (graphics1 == null) {
 			graphics1 = new kha.graphics2.Graphics1(this);
 		}
 		return graphics1;
 	}
-	
+
 	public var g2(get, null): kha.graphics2.Graphics;
-	
+
 	private function get_g2(): kha.graphics2.Graphics {
 		if (graphics2 == null) {
 			graphics2 = new kha.kore.graphics4.Graphics2(this);
 		}
 		return graphics2;
 	}
-	
+
 	public var g4(get, null): kha.graphics4.Graphics;
-	
+
 	private function get_g4(): kha.graphics4.Graphics {
 		if (graphics4 == null) {
 			graphics4 = new kha.kore.graphics4.Graphics(this);
 		}
 		return graphics4;
 	}
-	
+
 	public static var maxSize(get, null): Int;
-	
+
 	public static function get_maxSize(): Int {
 		return 4096;
 	}
-	
+
 	public static var nonPow2Supported(get, null): Bool;
-	
+
 	@:functionCode('return Kore::Graphics::nonPow2TexturesSupported();')
 	public static function get_nonPow2Supported(): Bool {
 		return false;
 	}
-	
+
 	public var width(get, null): Int;
 	public var height(get, null): Int;
-	
+
 	@:functionCode("if (texture != nullptr) return texture->width; else return renderTarget->width;")
 	public function get_width(): Int {
-		return 0; 
+		return 0;
 	}
-	
+
 	@:functionCode("if (texture != nullptr) return texture->height; else return renderTarget->height;")
 	public function get_height(): Int {
 		return 0;
 	}
-	
+
 	public var realWidth(get, null): Int;
 	public var realHeight(get, null): Int;
-	
+
 	@:functionCode("if (texture != nullptr) return texture->texWidth; else return renderTarget->texWidth;")
 	public function get_realWidth(): Int {
 		return 0;
 	}
-	
+
 	@:functionCode("if (texture != nullptr) return texture->texHeight; else return renderTarget->texHeight;")
 	public function get_realHeight(): Int {
 		return 0;
 	}
-	
+
 	@:functionCode("return (texture->at(x, y) & 0xff) != 0;")
 	public function isOpaque(x: Int, y: Int): Bool {
 		return true;
@@ -158,31 +178,31 @@ class Image implements Canvas implements Resource {
 	@:functionCode('return texture->at(x, y);')
 	private function atInternal(x: Int, y: Int): Int {
 		return 0;
-	} 
+	}
 
 	public inline function at(x: Int, y: Int): Color {
 		return Color.fromValue(atInternal(x, y));
 	}
-	
+
 	@:functionCode("delete texture; texture = nullptr; delete renderTarget; renderTarget = nullptr;")
 	public function unload(): Void {
-		
+
 	}
-	
+
 	private var bytes: Bytes = null;
-	
+
 	public function lock(level: Int = 0): Bytes {
 		bytes = Bytes.alloc(format == TextureFormat.RGBA32 ? 4 * width * height : width * height);
 		return bytes;
 	}
-	
+
 	@:functionCode('
 		Kore::u8* b = bytes->b->Pointer();
 		Kore::u8* tex = texture->lock();
 		for (int i = 0; i < ((texture->format == Kore::Image::RGBA32) ? (4 * texture->width * texture->height) : (texture->width * texture->height)); ++i) tex[i] = b[i];
 		texture->unlock();
 	')
-	public function unlock(): Void {	
+	public function unlock(): Void {
 		bytes = null;
 	}
 }

--- a/Sources/kha/DepthStencilFormat.hx
+++ b/Sources/kha/DepthStencilFormat.hx
@@ -1,0 +1,33 @@
+package kha;
+
+// normal 'enum DepthStencilFormat' declaration can't be used as default parameter
+@:enum abstract DepthStencilFormat(Int) {
+	var NoDepthAndStencil = 0;
+	var DepthOnly = 1;
+	var DepthAutoStencilAuto = 2;
+
+	// This is platform specific, use with care!
+	var Depth24Stencil8 = 3;
+	var Depth32Stencil8 = 4;
+
+	//var StencilOnlyIndex1 = 5;
+	//var StencilOnlyIndex4 = 6;
+	//var StencilOnlyIndex8 = 7;
+	//var StencilOnlyIndex16 = 8;
+}
+
+/*enum DepthStencilFormat {
+	NoDepthAndStencil;
+	DepthOnly;
+	DepthAutoStencilAuto;
+
+	// This is platform specific, use with care!
+	//Depth24Stencil8;
+	//Depth32Stencil8;
+
+	//StencilOnlyIndex1;
+	//StencilOnlyIndex4;
+	//StencilOnlyIndex8;
+	//StencilOnlyIndex16;
+}
+*/

--- a/Sources/kha/Image.hx
+++ b/Sources/kha/Image.hx
@@ -10,7 +10,7 @@ import kha.graphics4.Usage;
 extern class Image implements Canvas implements Resource {
 	/**
 	 * Create a new image instance.
-	 * 
+	 *
 	 * @param width		The image width.
  	 * @param height	The image height.
  	 * @param format	The image format, from TextureFormat, default = RGBA32.
@@ -20,14 +20,14 @@ extern class Image implements Canvas implements Resource {
 	public static function create(width: Int, height: Int, format: TextureFormat = TextureFormat.RGBA32, usage: Usage = Usage.StaticUsage, levels: Int = 1): Image;
 	/**
 	 * Create a new image instance and sets things up so you can render to the image.
-	 * 
+	 *
 	 * @param width					The image width.
  	 * @param height				The image height.
  	 * @param format				The image format, from TextureFormat, default = RGBA32.
- 	 * @param depthStencil			default = false
+ 	 * @param depthStencil			default = NoDepthAndStencil
 	 * @param antiAliasingSamples	The number of antialiasing samples, default = 1.
 	 */
-	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = TextureFormat.RGBA32, depthStencil: Bool = false, antiAliasingSamples: Int = 1): Image;
+	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = TextureFormat.RGBA32, depthStencil: DepthStencilFormat = NoDepthAndStencil, antiAliasingSamples: Int = 1): Image;
 	/**
 	 * The max image size.
 	 */


### PR DESCRIPTION
changes:

old:
```haxe
public static function createRenderTarget(... depthStencil: Bool = false, ... ): Image;
```

new:
```haxe
public static function createRenderTarget(... depthStencil: DepthStencilFormat = NoDepthAndStencil, ... ): Image;
```

Implemented for Flash, HTML5, Android, Kore (in extra PR https://github.com/KTXSoftware/Kore/pull/38)