### PR TITLE
Initial audio1 implementation for Unity backend.

### DIFF
--- a/Backends/Unity/UnityBackend.hx
+++ b/Backends/Unity/UnityBackend.hx
@@ -2,10 +2,12 @@ package;
 
 import haxe.io.BytesData;
 import unityEngine.Texture2D;
+import unityEngine.AudioClip;
 
 extern class UnityBackend {
 	public static function uvStartsAtTop(): Bool;
 	public static function loadImage(filename: String): Texture2D; 
 	public static function loadBlob(filename: String): BytesData;
+	public static function loadSound(filename: String): AudioClip;
 	public static function getImageSize(asset: Texture2D): Point;
 }

--- a/Backends/Unity/kha/LoaderImpl.hx
+++ b/Backends/Unity/kha/LoaderImpl.hx
@@ -22,11 +22,11 @@ class LoaderImpl {
 	}
 	
 	public static function loadSoundFromDescription(desc: Dynamic, done: Sound -> Void): Void {
-		done(new Sound());
+		done(new kha.unity.Sound(desc.files[0]));
 	}
 	
 	public static function getSoundFormats(): Array<String> {
-		return ["wav"];
+		return ["wav", "ogg"];
 	}
 	
 	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void): Void {

--- a/Backends/Unity/kha/audio1/Audio.hx
+++ b/Backends/Unity/kha/audio1/Audio.hx
@@ -1,13 +1,11 @@
 package kha.audio1;
 
-import kha.Sound;
-
 class Audio {
-	public static function play(sound: Sound, loop: Bool = false, stream: Bool = false): AudioChannel {
-		return null;
+	public static function play(sound: Sound, loop: Bool = false, stream: Bool = false): kha.audio1.AudioChannel {
+		return new UnitySoundChannel(cast(sound, kha.unity.Sound).filename, loop);
 	}
-	
-	//public static function playMusic(music: Music, loop: Bool = false): MusicChannel {
-	//	return new UnityMusicChannel();
+
+	//public static function playMusic(music: Music, loop: Bool = false): kha.audio1.MusicChannel {
+	//	return new UnityMusicChannel(cast(music, kha.unity.Music).filename, loop);
 	//}
 }

--- a/Backends/Unity/kha/audio1/UnityMusicChannel.hx
+++ b/Backends/Unity/kha/audio1/UnityMusicChannel.hx
@@ -1,20 +1,8 @@
 package kha.audio1;
 
-class UnityMusicChannel implements kha.audio1.MusicChannel {
-	public function new() {
-		
+class UnityMusicChannel extends UnitySoundChannel implements kha.audio1.MusicChannel {
+	public function new(filename: String, looping: Bool) {
+		super(filename);
+		source.loop = looping;
 	}
-	
-	public function play(): Void { }
-	public function pause(): Void { }
-	public function stop(): Void { }
-	public var length(get, null): Int;
-	private function get_length(): Int { return 0; }
-	public var position(get, null): Int;
-	private function get_position(): Int { return 0; }
-	public var volume(get, set): Float;
-	private function get_volume(): Float { return 1; }
-	private function set_volume(value: Float): Float { return 1; }
-	public var finished(get, null): Bool;
-	private function get_finished(): Bool { return false; }
 }

--- a/Backends/Unity/kha/audio1/UnitySoundChannel.hx
+++ b/Backends/Unity/kha/audio1/UnitySoundChannel.hx
@@ -1,20 +1,56 @@
 package kha.audio1;
 
-class UnitySoundChannel implements kha.audio1.SoundChannel {
-	public function new() {
-		
+import unityEngine.AudioSource;
+import unityEngine.GameObject;
+
+class UnitySoundChannel implements kha.audio1.AudioChannel {
+	static private var gameobject: GameObject = new GameObject("Audio Source");
+	private var source: AudioSource;
+	
+	public function new(filename: String, loop: Bool = false) {
+		source = untyped __cs__("global::kha.audio1.UnitySoundChannel.gameobject.AddComponent<global::UnityEngine.AudioSource>()");
+		source.clip = UnityBackend.loadSound(filename);
+		source.loop = loop;
+		play();
 	}
 	
-	public function play(): Void { }
-	public function pause(): Void { }
-	public function stop(): Void { }
-	public var length(get, null): Int;
-	private function get_length(): Int { return 0; }
-	public var position(get, null): Int;
-	private function get_position(): Int { return 0; }
+	public function play(): Void {
+		source.Play();
+	}
+	
+	public function pause(): Void {
+		source.Pause();
+	}
+	
+	public function stop(): Void {
+		source.Stop();
+	}
+	
+	public var length(get, null): Float;
+	
+	public function get_length(): Float {
+		return source.clip.length;
+	}
+	
+	public var position(get, null): Float;
+	
+	public function get_position(): Float {
+		return source.time;
+	}
+	
 	public var volume(get, set): Float;
-	private function get_volume(): Float { return 1; }
-	private function set_volume(value: Float): Float { return 1; }
+	
+	public function get_volume(): Float {
+		return source.volume;
+	}
+	
+	public function set_volume(value: Float): Float {
+		return source.volume = untyped __cs__("(float)value");
+	}
+	
 	public var finished(get, null): Bool;
-	private function get_finished(): Bool { return false; }
+	
+	public function get_finished(): Bool {
+		return !source.isPlaying;
+	}
 }

--- a/Backends/Unity/kha/unity/Sound.hx
+++ b/Backends/Unity/kha/unity/Sound.hx
@@ -1,7 +1,10 @@
 package kha.unity;
 
 class Sound extends kha.Sound {
-	public function new() {
+	public var filename: String;
+	
+	public function new(filename: String): Void {
 		super();
+		this.filename = filename;
 	}
 }

--- a/Backends/Unity/unityEngine/AudioClip.hx
+++ b/Backends/Unity/unityEngine/AudioClip.hx
@@ -1,0 +1,6 @@
+package unityEngine;
+
+@:native('UnityEngine.AudioClip')
+extern class AudioClip {
+	public var length: Float;
+}

--- a/Backends/Unity/unityEngine/AudioSource.hx
+++ b/Backends/Unity/unityEngine/AudioSource.hx
@@ -1,0 +1,14 @@
+package unityEngine;
+
+@:native('UnityEngine.AudioSource')
+extern class AudioSource {
+	public function new() : Void { }
+	public function Play() : Void { }
+	public function Pause() : Void { }
+	public function Stop() : Void { }
+	public var clip: AudioClip;
+	public var volume: Float;
+	public var time: Float;
+	public var isPlaying: Bool;
+	public var loop: Bool;
+}

--- a/Backends/Unity/unityEngine/GameObject.hx
+++ b/Backends/Unity/unityEngine/GameObject.hx
@@ -1,0 +1,6 @@
+package unityEngine;
+
+@:native('UnityEngine.GameObject')
+extern class GameObject {
+	public function new(name: String) : Void { }
+}

--- a/Sources/kha/audio1/AudioChannel.hx
+++ b/Sources/kha/audio1/AudioChannel.hx
@@ -5,12 +5,12 @@ interface AudioChannel {
 	public function pause(): Void;
 	public function stop(): Void;
 	public var length(get, null): Float; // Seconds
-	public function get_length(): Float;
+	private function get_length(): Float;
 	public var position(get, null): Float; // Seconds
-	public function get_position(): Float;
+	private function get_position(): Float;
 	public var volume(get, set): Float;
-	public function get_volume(): Float;
-	public function set_volume(value: Float): Float;
+	private function get_volume(): Float;
+	private function set_volume(value: Float): Float;
 	public var finished(get, null): Bool;
-	public function get_finished(): Bool;
+	private function get_finished(): Bool;
 }

--- a/Sources/kha/audio1/AudioChannel.hx
+++ b/Sources/kha/audio1/AudioChannel.hx
@@ -5,12 +5,12 @@ interface AudioChannel {
 	public function pause(): Void;
 	public function stop(): Void;
 	public var length(get, null): Float; // Seconds
-	private function get_length(): Float;
+	public function get_length(): Float;
 	public var position(get, null): Float; // Seconds
-	private function get_position(): Float;
+	public function get_position(): Float;
 	public var volume(get, set): Float;
-	private function get_volume(): Float;
-	private function set_volume(value: Float): Float;
+	public function get_volume(): Float;
+	public function set_volume(value: Float): Float;
 	public var finished(get, null): Bool;
-	private function get_finished(): Bool;
+	public function get_finished(): Bool;
 }


### PR DESCRIPTION
Here's my initial audio1 implementation for Unity.

I wasn't sure how to finish off getting MusicChannel working so I've left it commented out in Backends/Unity/kha/audio1/Audio.hx for now.

On line 48 of Backends/Unity/kha/audio1/UnitySoundChannel.hx I've explicitly written the C# code including a typecast for set_volume() to avoid a compiler error about implicit conversion from double to float - is there a better way to do this from the haxe side?

In Sources/kha/audio1/AudioChannel.hx I've changed some private functions to public - I assume that's how they are supposed to be defined?

Also I'm not sure about loading the sound in the UnitySoundChannel constructor - is there a better place I could put that? I'm not totally clear on how asset loading works in Kha yet.

