### PR TITLE
Image.generateMipmaps and anisotropic filtering on WebGL.

### DIFF
--- a/Backends/Android/kha/Image.hx
+++ b/Backends/Android/kha/Image.hx
@@ -361,6 +361,10 @@ class Image implements Canvas implements Resource {
 		bytes = null;
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -211,6 +211,10 @@ class Image implements Canvas implements Resource {
 		if (!readable) bytes = null;
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Backends/HTML5-Worker/kha/Image.hx
+++ b/Backends/HTML5-Worker/kha/Image.hx
@@ -46,6 +46,7 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return null; }
 	public function unlock(): Void { }
+	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return w; }

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -67,7 +67,8 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return null; }
 	public function unlock(): Void { }
-	public function setMipmaps(mipmaps: Array<Image>): Void { };
+	public function generateMipmaps(levels: Int): Void { }
+	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return 0; }
 	public var height(get, null): Int;

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -236,11 +236,17 @@ class WebGLImage extends Image {
 
 	}
 
+	override public function generateMipmaps(levels: Int): Void {
+		// WebGL requires to generate all mipmaps down to 1x1 size, ignoring levels for now
+		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, texture);
+		SystemImpl.gl.generateMipmap(GL.TEXTURE_2D);
+	}
+
 	override public function setMipmaps(mipmaps: Array<Image>): Void {
+		// Similar to generateMipmaps, specify all the levels down to 1x1 size
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, texture);
 		for (i in 0...mipmaps.length) {
 			SystemImpl.gl.texImage2D(GL.TEXTURE_2D, i + 1, GL.RGBA, GL.RGBA, format == TextureFormat.RGBA128 ? GL.FLOAT : GL.UNSIGNED_BYTE, cast(mipmaps[i], WebGLImage).image);
 		}
-		SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR_MIPMAP_LINEAR);
 	}
 }

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -259,6 +259,9 @@ class Graphics implements kha.graphics4.Graphics {
 			case LinearMipFilter:
 				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR_MIPMAP_LINEAR);
 			}
+			if (minificationFilter == AnisotropicFilter) {
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, SystemImpl.anisotropicFilter.TEXTURE_MAX_ANISOTROPY_EXT, 4);
+			}
 		}
 		
 		switch (magnificationFilter) {

--- a/Backends/Java/kha/Image.hx
+++ b/Backends/Java/kha/Image.hx
@@ -119,6 +119,10 @@ class Image implements Canvas implements Resource {
 		
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -206,6 +206,10 @@ class Image implements Canvas implements Resource {
 		bytes = null;
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Backends/Node/kha/Image.hx
+++ b/Backends/Node/kha/Image.hx
@@ -51,6 +51,7 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return bytes; }
 	public function unlock(): Void { }
+	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return w; }

--- a/Backends/PSM/kha/Image.hx
+++ b/Backends/PSM/kha/Image.hx
@@ -65,6 +65,10 @@ class Image {
 		
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Backends/Unity/kha/Image.hx
+++ b/Backends/Unity/kha/Image.hx
@@ -121,6 +121,10 @@ class Image implements Canvas implements Resource {
 		
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Backends/WPF/kha/Image.hx
+++ b/Backends/WPF/kha/Image.hx
@@ -137,6 +137,10 @@ class Image implements Resource {
 		
 	}
 
+	public function generateMipmaps(levels: Int): Void {
+		
+	}
+
 	public function setMipmaps(mipmaps: Array<Image>): Void {
 		
 	}

--- a/Sources/kha/Image.hx
+++ b/Sources/kha/Image.hx
@@ -58,6 +58,12 @@ extern class Image implements Canvas implements Resource {
 	 */
 	public function unlock(): Void;
 	/**
+	 * Generate texture mipmaps.
+	 *
+	 * @param levels 	Number of mipmap levels to generate.
+	 */
+	public function generateMipmaps(levels: Int): Void;
+	/**
 	 * Set custom texture mipmaps.
 	 *
 	 * @param mipmaps 	Array of images to be used for mipmap levels, starting at level 1.


### PR DESCRIPTION
Mipmaps stuff, as discussed on some APIs like D3D we will need to provide custom implementation as there is no function to auto generate mipmaps.