### PR TITLE
Changes in KhaActivity to handle onActivityResult

### DIFF
--- a/Backends/Android/android/app/Activity.hx
+++ b/Backends/Android/android/app/Activity.hx
@@ -1,6 +1,7 @@
 package android.app;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
@@ -22,6 +23,7 @@ extern class Activity extends Context {
 	function onStop(): Void;
 	function onDestroy(): Void;
 	function onRestart(): Void;
+	@:protected function onActivityResult(requestCode:Int, resultCode:Int, data:Intent): Void;
 	function requestWindowFeature(feature: Int): Void;
 	function setContentView(view: View): Void;
 	function finish(): Void;

--- a/Backends/Android/android/content/Intent.hx
+++ b/Backends/Android/android/content/Intent.hx
@@ -1,0 +1,5 @@
+package android.content;
+
+extern class Intent {
+
+}

--- a/Backends/Android/com/ktxsoftware/kha/ActivityResult.hx
+++ b/Backends/Android/com/ktxsoftware/kha/ActivityResult.hx
@@ -1,0 +1,7 @@
+package com.ktxsoftware.kha;
+
+import android.content.Intent;
+
+interface ActivityResult {
+	public function onResult(requestCode:Int, resultCode:Int, data:Intent):Void;
+}

--- a/Backends/Android/com/ktxsoftware/kha/KhaActivity.hx
+++ b/Backends/Android/com/ktxsoftware/kha/KhaActivity.hx
@@ -2,6 +2,7 @@ package com.ktxsoftware.kha;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Window;
@@ -106,6 +107,8 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	//private var sensorManager: SensorManager;
 	//private var accelerometer: Sensor;
 	//private var gyro: Sensor;
+
+	private var activityResults:Array<ActivityResult>;
 	
 	private static var instance: KhaActivity;
 		
@@ -224,4 +227,19 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	//		view.gyro(e.values[0], e.values[1], e.values[2]);
 	//	}
 	//}	
+
+	public function registerActivityResult(actResult:ActivityResult):Void {
+		if (activityResults == null)
+			activityResults = new Array<ActivityResult>();
+
+		activityResults.push(actResult);
+	}
+
+	@:protected
+	override function onActivityResult(requestCode:Int, resultCode:Int, data:Intent) {
+		if (activityResults != null) {
+			for (actResult in activityResults)
+				actResult.onResult(requestCode, resultCode, data);
+		}
+	}
 }


### PR DESCRIPTION
I'm creating a bluetooth extension for android-java, and I need to call KhaActivity.startActivityForResult (to ask the user to enable the bluetooth), and receive the result in KhaActivity.onActivityResult.
So I created a list of "ActivityResults" that are extensions that are registered to receive the results from onActivityResult.
What do you think.
