### PR TITLE
New class KhaExtension to handle extensions life cycle

### DIFF
--- a/Backends/Android/android/app/Activity.hx
+++ b/Backends/Android/android/app/Activity.hx
@@ -1,6 +1,7 @@
 package android.app;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
@@ -22,6 +23,7 @@ extern class Activity extends Context {
 	function onStop(): Void;
 	function onDestroy(): Void;
 	function onRestart(): Void;
+	@:protected function onActivityResult(requestCode:Int, resultCode:Int, data:Intent): Void;
 	function requestWindowFeature(feature: Int): Void;
 	function setContentView(view: View): Void;
 	function finish(): Void;

--- a/Backends/Android/android/content/Intent.hx
+++ b/Backends/Android/android/content/Intent.hx
@@ -1,0 +1,5 @@
+package android.content;
+
+extern class Intent {
+
+}

--- a/Backends/Android/com/ktxsoftware/kha/ActivityResult.hx
+++ b/Backends/Android/com/ktxsoftware/kha/ActivityResult.hx
@@ -1,0 +1,7 @@
+package com.ktxsoftware.kha;
+
+import android.content.Intent;
+
+interface ActivityResult {
+	public function onResult(requestCode:Int, resultCode:Int, data:Intent):Void;
+}

--- a/Backends/Android/com/ktxsoftware/kha/ActivityResult.hx
+++ b/Backends/Android/com/ktxsoftware/kha/ActivityResult.hx
@@ -1,7 +1,0 @@
-package com.ktxsoftware.kha;
-
-import android.content.Intent;
-
-interface ActivityResult {
-	public function onResult(requestCode:Int, resultCode:Int, data:Intent):Void;
-}

--- a/Backends/Android/com/ktxsoftware/kha/KhaActivity.hx
+++ b/Backends/Android/com/ktxsoftware/kha/KhaActivity.hx
@@ -108,7 +108,7 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	//private var accelerometer: Sensor;
 	//private var gyro: Sensor;
 
-	private var activityResults:Array<ActivityResult>;
+	private var extensions:Array<KhaExtension>;
 	
 	private static var instance: KhaActivity;
 		
@@ -145,6 +145,11 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 		//audio.pause();
 		//audio.flush();
 		view.queueEvent(new OnPauseRunner());
+
+		if (extensions != null) {
+			for (ext in extensions)
+				ext.onPause();
+		}
 	}
 	
 	override public function onResume(): Void {
@@ -183,11 +188,21 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 		audioThread.start();*/
 		
 		view.queueEvent(new OnResumeRunner());
+
+		if (extensions != null) {
+			for (ext in extensions)
+				ext.onResume();
+		}
 	}
 	
 	override public function onStop(): Void {
 		super.onStop();
 		view.queueEvent(new OnStopRunner());
+
+		if (extensions != null) {
+			for (ext in extensions)
+				ext.onStop();
+		}
 	}
 	
 	
@@ -197,8 +212,13 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	}
 	
 	override public function onDestroy(): Void {
+		if (extensions != null) {
+			for (ext in extensions)
+				ext.onDestroy();
+		}
+
 		super.onDestroy();
-		view.queueEvent(new OnDestroyRunner());
+		view.queueEvent(new OnDestroyRunner());		
 	}
 	
 	override public function onConfigurationChanged(newConfig: Configuration): Void {
@@ -228,18 +248,18 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	//	}
 	//}	
 
-	public function registerActivityResult(actResult:ActivityResult):Void {
-		if (activityResults == null)
-			activityResults = new Array<ActivityResult>();
+	public function registerExtension(ext:KhaExtension):Void {
+		if (extensions == null)
+			extensions = new Array<KhaExtension>();
 
-		activityResults.push(actResult);
+		extensions.push(ext);
 	}
 
 	@:protected
-	override function onActivityResult(requestCode:Int, resultCode:Int, data:Intent) {
-		if (activityResults != null) {
-			for (actResult in activityResults)
-				actResult.onResult(requestCode, resultCode, data);
+	override function onActivityResult(requestCode:Int, resultCode:Int, data:Intent):Void {
+		if (extensions != null) {
+			for (ext in extensions)
+				ext.onActivityResult(requestCode, resultCode, data);
 		}
 	}
 }

--- a/Backends/Android/com/ktxsoftware/kha/KhaActivity.hx
+++ b/Backends/Android/com/ktxsoftware/kha/KhaActivity.hx
@@ -2,6 +2,7 @@ package com.ktxsoftware.kha;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Window;
@@ -106,6 +107,8 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	//private var sensorManager: SensorManager;
 	//private var accelerometer: Sensor;
 	//private var gyro: Sensor;
+
+	private var activityResults:Array<ActivityResult>;
 	
 	private static var instance: KhaActivity;
 		
@@ -224,4 +227,19 @@ class KhaActivity extends Activity /*implements SensorEventListener*/ {
 	//		view.gyro(e.values[0], e.values[1], e.values[2]);
 	//	}
 	//}	
+
+	public function registerActivityResult(actResult:ActivityResult):Void {
+		if (activityResults == null)
+			activityResults = new Array<ActivityResult>();
+
+		activityResults.push(actResult);
+	}
+
+	@:protected
+	override function onActivityResult(requestCode:Int, resultCode:Int, data:Intent) {
+		if (activityResults != null) {
+			for (actResult in activityResults)
+				actResult.onResult(requestCode, resultCode, data);
+		}
+	}
 }

--- a/Backends/Android/com/ktxsoftware/kha/KhaExtension.hx
+++ b/Backends/Android/com/ktxsoftware/kha/KhaExtension.hx
@@ -1,0 +1,23 @@
+package com.ktxsoftware.kha;
+
+import android.content.Intent;
+
+class KhaExtension {
+	public function new() {
+	}
+
+	public function onPause() {		
+	}
+
+	public function onResume() {		
+	}
+
+	public function onStop() {		
+	}	
+
+	public function onDestroy() {		
+	}
+
+	public function onActivityResult(requestCode:Int, resultCode:Int, data:Intent):Void {
+	}	
+}


### PR DESCRIPTION
I created the class KhaExtension that can be registered to be called in some events in the KhaActivity. In my case I need this to use the events onDestroy and onActivityResult of the activity.

Basically a extension extends KhaExtension, register itself with KhaActivity.the().registerExtension(), and then override the functions that will be called in the KhaActivity.

Check if the code is good.