### PR TITLE
renamed audio2.Audio.playMusic() to audio2.Audio.play()

### DIFF
--- a/Backends/Kore/kha/audio2/Audio.hx
+++ b/Backends/Kore/kha/audio2/Audio.hx
@@ -4,7 +4,7 @@ import kha.Sound;
 
 class Audio {
 	private static var buffer: Buffer;
-	
+
 	@:noCompletion
 	public static function _init() {
 		var bufferSize = 1024 * 2;
@@ -40,8 +40,8 @@ class Audio {
 	}
 
 	public static var audioCallback: Int->Buffer->Void;
-	
-	public static function playMusic(sound: Sound, loop: Bool = false): AudioChannel {
+
+	public static function play(sound: Sound, loop: Bool = false): AudioChannel {
 		return null;
 	}
 }


### PR DESCRIPTION
I'm trying this and couldn't compile windows target b/c kha.audio2.Audio.play wasn't found (It does compile on flash).

```haxe
var channel : kha.audio1.AudioChannel = kha.audio2.Audio.play(sound, loop);

if (channel == null) {
    channel = kha.audio1.Audio.play(sound, loop);
}
```

Was this just overlooked when you renamed stuff or am i using it wrong? 
