### PR TITLE
Depth16 compile fix flash

### DIFF
--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -174,6 +174,8 @@ class Image implements Canvas implements Resource {
 					bytes = Bytes.alloc(texWidth * texHeight);
 				case RGBA128:
 					bytes = Bytes.alloc(texWidth * texHeight * 16);
+				case DEPTH16:
+					bytes = Bytes.alloc(texWidth * texHeight * 2);
 			}
 		}
 		return bytes;
@@ -213,7 +215,7 @@ class Image implements Canvas implements Resource {
 	}
 
 	public function generateMipmaps(levels: Int): Void {
-		
+
 	}
 
 	public function setMipmaps(mipmaps: Array<Image>): Void {


### PR DESCRIPTION
the switch in Image.lock() was missing the new DEPTH16 case