### PR TITLE
DEPTH16 render target for WebGL.

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -31,6 +31,7 @@ class GamepadStates {
 class SystemImpl {
 	public static var gl: GL;
 	public static var anisotropicFilter: Dynamic;
+	public static var depthTexture: Dynamic;
 	public static var drawBuffers: Dynamic;
 	@:noCompletion public static var _hasWebAudio: Bool;
 	//public static var graphics(default, null): Graphics;
@@ -227,6 +228,7 @@ class SystemImpl {
 				SystemImpl.gl.pixelStorei(GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
 				SystemImpl.gl.getExtension("OES_texture_float");
 				SystemImpl.gl.getExtension("OES_texture_float_linear");
+				depthTexture = SystemImpl.gl.getExtension("WEBGL_depth_texture");
 				SystemImpl.gl.getExtension("EXT_shader_texture_lod");
 				SystemImpl.gl.getExtension("OES_standard_derivatives");
 				anisotropicFilter = SystemImpl.gl.getExtension("EXT_texture_filter_anisotropic");

--- a/Backends/HTML5/kha/graphics4/PipelineState.hx
+++ b/Backends/HTML5/kha/graphics4/PipelineState.hx
@@ -46,6 +46,7 @@ class PipelineState extends PipelineStateBase {
 	public function set(): Void {
 		SystemImpl.gl.useProgram(program);
 		for (index in 0...textureValues.length) SystemImpl.gl.uniform1i(textureValues[index], index);
+		SystemImpl.gl.colorMask(colorWriteMaskRed, colorWriteMaskGreen, colorWriteMaskBlue, colorWriteMaskAlpha);
 	}
 	
 	private function compileShader(shader: Dynamic): Void {


### PR DESCRIPTION
For the reasons beyond me, OSX(and apparently Linux) WebGL implementations throw incomplete framebuffer error when there is no color attached. As a workaround I create one. Windows works as expected.

I also did some cleaning around, as we get more features in it gets crowded and bogs down readability, hope it is fine!