### PR TITLE
fix render target using flash

### DIFF
--- a/Backends/Flash/kha/SystemImpl.hx
+++ b/Backends/Flash/kha/SystemImpl.hx
@@ -110,6 +110,7 @@ class SystemImpl {
 
 	private static function update(_): Void {
 		Scheduler.executeFrame();
+		context.setRenderToBackBuffer();
 		context.clear(0, 0, 0, 0);
 		System.render(0, frame);
 		context.present();

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -428,6 +428,6 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function end(): Void {
-
+		context.setRenderToBackBuffer();
 	}
 }

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -428,6 +428,6 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function end(): Void {
-		context.setRenderToBackBuffer();
+
 	}
 }


### PR DESCRIPTION
graphics.begin() sets the correct render target but dosent set it back to backbuffer, SystemImpl shouldnt assume it has backbuffer as a target. Otherwise the  error " Error #3692:All buffers need to be cleared every frame before drawing" is thrown after drawing to a render target Image.