### PR TITLE
Added Display.widthPrimary and Display.heightPrimary

### DIFF
--- a/Backends/Android/kha/DisplayImpl.hx
+++ b/Backends/Android/kha/DisplayImpl.hx
@@ -14,4 +14,14 @@ class DisplayImpl {
         trace('TODO (DK) implement me');
         return -1;
 	}
+
+	public static function widthPrimary() : Int {
+        trace('TODO (DK) implement me');
+        return -1;
+	}
+
+	public static function heightPrimary() : Int {
+        trace('TODO (DK) implement me');
+        return -1;
+	}
 }

--- a/Backends/Flash/kha/DisplayImpl.hx
+++ b/Backends/Flash/kha/DisplayImpl.hx
@@ -12,4 +12,12 @@ class DisplayImpl {
     public static function height( id : Int ) : Int {
         return flash.Lib.current.stage.fullScreenHeight;
     }
+
+    public static function widthPrimary() : Int {
+        return width(0);
+    }
+
+    public static function heightPrimary() : Int {
+        return height(0);
+    }
 }

--- a/Backends/HTML5/kha/DisplayImpl.hx
+++ b/Backends/HTML5/kha/DisplayImpl.hx
@@ -14,4 +14,14 @@ class DisplayImpl {
 		trace('TODO (DK) implement me');
         return -1;
 	}
+
+	public static function widthPrimary() : Int {
+        trace('TODO (DK) implement me');
+        return -1;
+	}
+
+	public static function heightPrimary() : Int {
+        trace('TODO (DK) implement me');
+        return -1;
+	}
 }

--- a/Backends/Kore/kha/DisplayImpl.hx
+++ b/Backends/Kore/kha/DisplayImpl.hx
@@ -5,6 +5,8 @@ namespace Kore { namespace Display {
 	int count();
 	int width(int);
 	int height(int);
+	int widthPrimary();
+	Int heightPrimary();
 }}
 ')
 class DisplayImpl {
@@ -18,5 +20,13 @@ class DisplayImpl {
 
     public static function height( index : Int ) : Int {
         return untyped __cpp__('Kore::Display::height(index)');
+    }
+	
+	public static function widthPrimary() : Int {
+        return untyped __cpp__('Kore::Display::widthPrimary()');
+    }
+
+    public static function heightPrimary() : Int {
+        return untyped __cpp__('Kore::Display::heightPrimary()');
     }
 }

--- a/Backends/Unity/kha/DisplayImpl.hx
+++ b/Backends/Unity/kha/DisplayImpl.hx
@@ -14,4 +14,14 @@ class DisplayImpl {
         trace('TODO (DK) implement me');
         return -1;
 	}
+
+	public static function widthPrimary() : Int {
+        trace('TODO (DK) implement me');
+        return -1;
+	}
+
+	public static function heightPrimary() : Int {
+        trace('TODO (DK) implement me');
+        return -1;
+	}
 }

--- a/Sources/kha/Display.hx
+++ b/Sources/kha/Display.hx
@@ -10,6 +10,14 @@ class Display {
     public static function height( index : Int ) : Int {
         return DisplayImpl.height(index);
     }
+	
+	public static function widthPrimary() : Int {
+        return DisplayImpl.widthPrimary();
+    }
+
+    public static function heightPrimary() : Int {
+        return DisplayImpl.heightPrimary();
+    }
 
 	static inline function get_count() : Int {
 		return DisplayImpl.count();


### PR DESCRIPTION
Display.widthPrimary and Display.heightPrimary returns the size of the primary display. I just used the code that was already in Kore. The only version implemented is windows, there is code to get the primary display in linux but is crashing in my system, so I removed the implementation. The Pi was following the linux implementation, but I don't have a Pi to test for now so I removed too.