### PR TITLE
Image.fromBytes with WebGL implementation.

### DIFF
--- a/Backends/Android/kha/Image.hx
+++ b/Backends/Android/kha/Image.hx
@@ -239,6 +239,10 @@ class Image implements Canvas implements Resource {
 		if (format == null) format = TextureFormat.RGBA32;
 		return new Image(width, height, format, true, depthStencil);
 	}
+	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 
 	public var g1(get, null): kha.graphics1.Graphics;
 

--- a/Backends/Empty/kha/Image.hx
+++ b/Backends/Empty/kha/Image.hx
@@ -13,6 +13,10 @@ class Image implements Canvas implements Resource {
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = DepthStencilFormat.NoDepthAndStencil, antiAliasingSamples: Int = 1): Image {
 		return null;
 	}
+	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 
 	public static var maxSize(get, null): Int;
 

--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -36,6 +36,10 @@ class Image implements Canvas implements Resource {
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = DepthStencilFormat.NoDepthAndStencil, antiAliasingSamples: Int = 1, contextId: Int = 0): Image {
 		return new Image(width, height, format == null ? TextureFormat.RGBA32 : format, true, depthStencil, false);
 	}
+	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 
 	public function new(width: Int, height: Int, format: TextureFormat, renderTarget: Bool, depthStencil: DepthStencilFormat, readable: Bool) {
 		myWidth = width;

--- a/Backends/HTML5-Worker/kha/Image.hx
+++ b/Backends/HTML5-Worker/kha/Image.hx
@@ -30,6 +30,10 @@ class Image implements Canvas implements Resource {
 		return null;
 	}
 	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+	
 	public static var maxSize(get, null): Int;
 	
 	public static function get_maxSize(): Int {

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -36,10 +36,12 @@ class Image implements Canvas implements Resource {
 		}
 	}
 	
-	public static function fromFloats(data: haxe.io.Float32Array, width: Int, height: Int, readable: Bool, halfFloat: Bool = false): Image {
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		if (format == null) format = TextureFormat.RGBA32;
+		if (usage == null) usage = Usage.StaticUsage;
 		if (SystemImpl.gl != null) {
-			var img = new WebGLImage(width, height, halfFloat ? TextureFormat.RGBA64 : TextureFormat.RGBA128, false, DepthStencilFormat.NoDepthAndStencil);
-			img.image = data.view;
+			var img = new WebGLImage(width, height, format, false, DepthStencilFormat.NoDepthAndStencil);
+			img.image = img.bytesToArray(bytes);
 			img.createTexture();
 			return img;
 		}

--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -4,14 +4,16 @@ import js.Boot;
 import js.Browser;
 import js.html.audio.DynamicsCompressorNode;
 import js.html.ImageElement;
+import js.Lib;
+import js.html.XMLHttpRequest;
+import haxe.io.Bytes;
+import haxe.io.BytesData;
 import kha.FontStyle;
 import kha.Blob;
 import kha.js.WebAudioSound;
 import kha.Kravur;
-import haxe.io.Bytes;
-import haxe.io.BytesData;
-import js.Lib;
-import js.html.XMLHttpRequest;
+import kha.graphics4.TextureFormat;
+import kha.graphics4.Usage;
 
 using StringTools;
 
@@ -25,7 +27,7 @@ class LoaderImpl {
 		if (StringTools.endsWith(desc.files[0], ".hdr")) {
 			loadBlobFromDescription(desc, function(blob) {
 				var hdrImage = kha.internal.HdrFormat.parse(blob.toBytes());
-				done(Image.fromFloats(hdrImage.data, hdrImage.width, hdrImage.height, readable));
+				done(Image.fromBytes(hdrImage.data.view.buffer, hdrImage.width, hdrImage.height, TextureFormat.RGBA128, readable ? Usage.DynamicUsage : Usage.StaticUsage));
 			});
 		}
 		else {

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -226,7 +226,7 @@ class WebGLImage extends Image {
 		if (video != null) SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, video);
 	}
 
-	private function formatByteSize(format: TextureFormat): Int {
+	private static function formatByteSize(format: TextureFormat): Int {
 		return switch(format) {
 			case RGBA32: 4;
 			case L8: 1;
@@ -236,6 +236,17 @@ class WebGLImage extends Image {
 			case A32: 4;
 			case A16: 2;
 			default: 4;
+		}
+	}
+	
+	public function bytesToArray(bytes: Bytes): Dynamic {
+		return switch(format) {
+			case RGBA32, L8:
+				new Uint8Array(bytes.getData());
+			case RGBA128, RGBA64, A32, A16:
+				new Float32Array(bytes.getData());
+			default:
+				new Uint8Array(bytes.getData());
 		}
 	}
 
@@ -260,7 +271,7 @@ class WebGLImage extends Image {
 
 			switch (format) {
 			case L8:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, width, height, 0, GL.LUMINANCE, GL.UNSIGNED_BYTE, new Uint8Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, width, height, 0, GL.LUMINANCE, GL.UNSIGNED_BYTE, bytesToArray(bytes));
 
 				if (SystemImpl.gl.getError() == 1282) { // no LUMINANCE support in IE11
 					var rgbaBytes = Bytes.alloc(width * height * 4);
@@ -271,20 +282,20 @@ class WebGLImage extends Image {
 						rgbaBytes.set(y * width * 4 + x * 4 + 2, value);
 						rgbaBytes.set(y * width * 4 + x * 4 + 3, 255);
 					}
-					SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, new Uint8Array(rgbaBytes.getData()));
+					SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, bytesToArray(rgbaBytes));
 				}
 			case RGBA128:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.FLOAT, new Float32Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.FLOAT, bytesToArray(bytes));
 			case RGBA64:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, SystemImpl.halfFloat.HALF_FLOAT_OES, new Float32Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, SystemImpl.halfFloat.HALF_FLOAT_OES, bytesToArray(bytes));
 			case A32:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, width, height, 0, GL.ALPHA, GL.FLOAT, new Float32Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, width, height, 0, GL.ALPHA, GL.FLOAT, bytesToArray(bytes));
 			case A16:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, width, height, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, new Float32Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, width, height, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, bytesToArray(bytes));
 			case RGBA32:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, new Uint8Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, bytesToArray(bytes));
 			default:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, new Uint8Array(bytes.getData()));
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, bytesToArray(bytes));
 			}
 
 			SystemImpl.gl.bindTexture(GL.TEXTURE_2D, null);

--- a/Backends/Java/kha/Image.hx
+++ b/Backends/Java/kha/Image.hx
@@ -35,6 +35,10 @@ class Image implements Canvas implements Resource {
 		return img;
 	}
 	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+	
 	public var g1(get, null): kha.graphics1.Graphics;
 	
 	private function get_g1(): kha.graphics1.Graphics {

--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -34,6 +34,10 @@ class Image implements Canvas implements Resource {
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = NoDepthAndStencil, antiAliasingSamples: Int = 1, contextId: Int = 0): Image {
 		return create2(width, height, format == null ? TextureFormat.RGBA32 : format, false, true, depthStencil, contextId);
 	}
+	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 
 	private function new(readable: Bool) {
 		this.readable = readable;

--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -31,6 +31,10 @@ class Image implements Canvas implements Resource {
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = NoDepthAndStencil, antiAliasingSamples: Int = 1, contextId: Int = 0): Image {
 		return create2(width, height, format == null ? TextureFormat.RGBA32 : format, false, true, depthStencil, contextId);
 	}
+	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 
 	private function new(readable: Bool) {
 		this.readable = readable;

--- a/Backends/Node/kha/Image.hx
+++ b/Backends/Node/kha/Image.hx
@@ -34,6 +34,10 @@ class Image implements Canvas implements Resource {
 		return new Image(width, height, format);
 	}
 	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+	
 	public static var maxSize(get, null): Int;
 	
 	public static function get_maxSize(): Int {

--- a/Backends/PSM/kha/Image.hx
+++ b/Backends/PSM/kha/Image.hx
@@ -21,6 +21,10 @@ class Image {
 		return null;
 	}
 	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+	
 	public function new(filename: String) {
 		texture = new Texture2D("/Application/resources/" + filename, false);
 	}

--- a/Backends/Unity/kha/Image.hx
+++ b/Backends/Unity/kha/Image.hx
@@ -25,6 +25,10 @@ class Image implements Canvas implements Resource {
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencilFormat: DepthStencilFormat = NoDepthAndStencil, antiAliasingSamples: Int = 1, contextId: Int = 0): Image {
 		return new Image(width, height, format == null ? TextureFormat.RGBA32 : format, true);
 	}
+	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 
 	private static function upperPowerOfTwo(v: Int): Int {
 		v--;

--- a/Backends/WPF/kha/Image.hx
+++ b/Backends/WPF/kha/Image.hx
@@ -29,6 +29,10 @@ class Image implements Resource {
 		return null;
 	}
 	
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+	
 	public function new(width: Int, height: Int, format: TextureFormat) {
 		myWidth = width;
 		myHeight = height;

--- a/Sources/kha/Image.hx
+++ b/Sources/kha/Image.hx
@@ -17,6 +17,12 @@ extern class Image implements Canvas implements Resource {
  	 * @param usage		If you plan to change the vertex after or not, from Usage, default = StaticUsage.
 	 */
 	public static function create(width: Int, height: Int, format: TextureFormat = TextureFormat.RGBA32, usage: Usage = Usage.StaticUsage): Image;
+
+	/**
+	 * Create a new image instance from bytes.
+	 */
+	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = TextureFormat.RGBA32, usage: Usage = Usage.StaticUsage): Image;
+
 	/**
 	 * Create a new image instance and sets things up so you can render to the image.
 	 *


### PR DESCRIPTION
Need a fast way to construct images from already allocated bytes, this is the most efficient/straightforward way I figured. Thoughts?