### PR TITLE
Bindable depth buffers.

### DIFF
--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -191,6 +191,10 @@ class Graphics implements kha.graphics4.Graphics {
 			texture.set(cast(stage, TextureUnit).value);
 		}
 	}
+	
+	public function setTextureDepth(stage: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+	
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -274,6 +274,10 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setTexture(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
 		context.setTextureAt(cast(unit, TextureUnit).unit, texture == null ? null : cast(texture, Image).getFlashTexture());
 	}
+	
+	public function setTextureDepth(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+			
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -24,7 +24,7 @@ class WebGLImage extends Image {
 	private var format: TextureFormat;
 	private var renderTarget: Bool;
 	public var frameBuffer: Dynamic;
-	// public var renderBuffer: Dynamic;
+	public var renderBuffer: Dynamic;
 	public var texture: Dynamic;
 	public var depthTexture: Dynamic;
 
@@ -173,38 +173,7 @@ class WebGLImage extends Image {
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
 			}
 
-			switch (depthStencilFormat) {
-			case NoDepthAndStencil: {}
-			case DepthOnly: {
-				depthTexture = SystemImpl.gl.createTexture();
-				SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_COMPONENT, realWidth, realHeight, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_INT, null);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
-				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
-				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
-				// renderBuffer = SystemImpl.gl.createRenderbuffer();
-				// SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
-				// SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, realWidth, realHeight);
-				// SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
-			}
-			case DepthAutoStencilAuto, Depth24Stencil8, Depth32Stencil8:
-				depthTexture = SystemImpl.gl.createTexture();
-				SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_STENCIL, realWidth, realHeight, 0, GL.DEPTH_STENCIL, SystemImpl.depthTexture.UNSIGNED_INT_24_8_WEBGL, null);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
-				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
-				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
-				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0); 
-				// renderBuffer = SystemImpl.gl.createRenderbuffer();
-				// SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
-				// SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_STENCIL, realWidth, realHeight);
-				// SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
-			}
+			initDepthStencilBuffer(depthStencilFormat);
 
 			SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, null);
 			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, null);
@@ -229,6 +198,49 @@ class WebGLImage extends Image {
 			}
 		}
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, null);
+	}
+	
+	private function initDepthStencilBuffer(depthStencilFormat: DepthStencilFormat) {
+		switch (depthStencilFormat) {
+		case NoDepthAndStencil: {}
+		case DepthOnly: {
+			if (SystemImpl.depthTexture == null) {
+				renderBuffer = SystemImpl.gl.createRenderbuffer();
+				SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
+				SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, realWidth, realHeight);
+				SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
+			}
+			else {
+				depthTexture = SystemImpl.gl.createTexture();
+				SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_COMPONENT, realWidth, realHeight, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_INT, null);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
+			}
+		}
+		case DepthAutoStencilAuto, Depth24Stencil8, Depth32Stencil8:
+			if (SystemImpl.depthTexture == null) {
+				renderBuffer = SystemImpl.gl.createRenderbuffer();
+				SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, renderBuffer);
+				SystemImpl.gl.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_STENCIL, realWidth, realHeight);
+				SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.RENDERBUFFER, renderBuffer);
+			}
+			else {
+				depthTexture = SystemImpl.gl.createTexture();
+				SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_STENCIL, realWidth, realHeight, 0, GL.DEPTH_STENCIL, SystemImpl.depthTexture.UNSIGNED_INT_24_8_WEBGL, null);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
+			} 
+		}
 	}
 
 	public function set(stage: Int): Void {

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -178,7 +178,11 @@ class WebGLImage extends Image {
 			case DepthOnly: {
 				depthTexture = SystemImpl.gl.createTexture();
 				SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_COMPONENT, realWidth, realHeight, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_SHORT, null);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_COMPONENT, realWidth, realHeight, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_INT, null);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
 				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
 				// renderBuffer = SystemImpl.gl.createRenderbuffer();
@@ -189,7 +193,11 @@ class WebGLImage extends Image {
 			case DepthAutoStencilAuto, Depth24Stencil8, Depth32Stencil8:
 				depthTexture = SystemImpl.gl.createTexture();
 				SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_STENCIL, realWidth, realHeight, 0, GL.DEPTH_STENCIL, GL.UNSIGNED_SHORT, null);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.DEPTH_STENCIL, realWidth, realHeight, 0, GL.DEPTH_STENCIL, SystemImpl.depthTexture.UNSIGNED_INT_24_8_WEBGL, null);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
 				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0); 
 				// renderBuffer = SystemImpl.gl.createRenderbuffer();

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -228,6 +228,10 @@ class Graphics implements kha.graphics4.Graphics {
 			cast(texture, WebGLImage).set(cast(stage, TextureUnit).value);
 		}
 	}
+	
+	public function setTextureDepth(stage: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+		cast(texture, WebGLImage).setDepth(cast(stage, TextureUnit).value);
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 		if (texture == null) {

--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -376,6 +376,10 @@ class Graphics implements kha.graphics4.Graphics {
 		if (texture == null) return;
 		setTextureInternal(cast unit, texture);
 	}
+	
+	public function setTextureDepth(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+		
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 		if (texture == null) return;

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -289,6 +289,10 @@ class Graphics implements kha.graphics4.Graphics {
 		if (texture == null) return;
 		setTextureInternal(cast unit, texture);
 	}
+	
+	public function setTextureDepth(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+	
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 		if (texture == null) return;

--- a/Backends/Node/kha/js/EmptyGraphics4.hx
+++ b/Backends/Node/kha/js/EmptyGraphics4.hx
@@ -97,6 +97,10 @@ class EmptyGraphics4 implements Graphics {
 	public function setTexture(unit: TextureUnit, texture: Image): Void {
 		
 	}
+	
+	public function setTextureDepth(unit: TextureUnit, texture: Image): Void {
+		
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 

--- a/Backends/PSM/kha/psm/graphics4/Graphics.hx
+++ b/Backends/PSM/kha/psm/graphics4/Graphics.hx
@@ -117,6 +117,10 @@ class Graphics implements kha.graphics4.Graphics {
 			context.SetTexture(0, texture.texture);
 		}
 	}
+	
+	public function setTextureDepth(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+	
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 

--- a/Backends/Unity/kha/unity/Graphics.hx
+++ b/Backends/Unity/kha/unity/Graphics.hx
@@ -121,6 +121,10 @@ class Graphics implements kha.graphics4.Graphics {
 		if (texture == null) return;
 		pipeline.material.SetTexture(cast(unit, kha.unity.TextureUnit).name, texture.texture);
 	}
+	
+	public function setTextureDepth(unit: TextureUnit, texture: Image): Void {
+	
+	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 

--- a/Sources/kha/graphics4/Graphics.hx
+++ b/Sources/kha/graphics4/Graphics.hx
@@ -29,6 +29,7 @@ interface Graphics {
 	function setIndexBuffer(indexBuffer: IndexBuffer): Void;
 	
 	function setTexture(unit: TextureUnit, texture: Image): Void;
+	function setTextureDepth(unit: TextureUnit, texture: Image): Void;
 	function setVideoTexture(unit: TextureUnit, texture: Video): Void;
 	function setTextureParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void;
 	//function maxTextureSize(): Int;


### PR DESCRIPTION
g4.setTextureDepth(unit, image) can be used to bind depth buffer of texture to sampler.

Implemented for WebGL first. Renderbuffer is still used as a fallback if depth texture is not supported (rare case).