### PR TITLE
 fast matrix and blob bytes

### DIFF
--- a/Backends/Flash/kha/Blob.hx
+++ b/Backends/Flash/kha/Blob.hx
@@ -5,11 +5,16 @@ import haxe.io.Bytes;
 import haxe.io.BytesData;
 
 class Blob implements Resource {
-	public var bytes: BytesData;
+	var bytesData: BytesData;
+	
+	public var bytes(get, never):Bytes;
+	function get_bytes() {
+		return Bytes.ofData(bytesData);
+	}
 	
 	@:allow(kha.LoaderImpl)
 	private function new(bytes: BytesData) {
-		this.bytes = bytes;
+		this.bytesData = bytes;
 	}
 	
 	public static function fromBytes(bytes: Bytes): Blob {
@@ -24,118 +29,118 @@ class Blob implements Resource {
 	
 	public function sub(start: Int, length: Int): Blob {
 		var b = new BytesData();
-		bytes.position = start;
-		bytes.readBytes(b, 0, length);
+		bytesData.position = start;
+		bytesData.readBytes(b, 0, length);
 		return new Blob(b);
 	}
 	
 	public var length(get, null): Int;
 	
 	public function get_length(): Int {
-		return bytes.length;
+		return bytesData.length;
 	}
 	
 	public function writeU8(position: Int, value: Int): Void {
-		bytes[position] = value;
+		bytesData[position] = value;
 	}
 	
 	private function le(): Void {
-		bytes.endian = Endian.LITTLE_ENDIAN;
+		bytesData.endian = Endian.LITTLE_ENDIAN;
 	}
 	
 	private function be(): Void {
-		bytes.endian = Endian.BIG_ENDIAN;
+		bytesData.endian = Endian.BIG_ENDIAN;
 	}
 	
 	public function readS8(position: Int): Int {
-		bytes.position = position;
-		return bytes.readByte();
+		bytesData.position = position;
+		return bytesData.readByte();
 	}
 	
 	public function readU8(position: Int): Int {
-		bytes.position = position;
-		var value = bytes.readUnsignedByte();
+		bytesData.position = position;
+		var value = bytesData.readUnsignedByte();
 		return value;
 	}
 		
 	public function readS16LE(position: Int): Int {
 		le();
-		bytes.position = position;
-		return bytes.readShort();
+		bytesData.position = position;
+		return bytesData.readShort();
 	}
 	
 	public function readS16BE(position: Int): Int {
 		be();
-		bytes.position = position;
-		return bytes.readShort();
+		bytesData.position = position;
+		return bytesData.readShort();
 	}
 	
 	public function readU16LE(position: Int): Int {
 		le();
-		bytes.position = position;
-		return bytes.readUnsignedShort();
+		bytesData.position = position;
+		return bytesData.readUnsignedShort();
 	}
 	
 	public function readU16BE(position: Int): Int {
 		be();
-		bytes.position = position;
-		return bytes.readUnsignedShort();
+		bytesData.position = position;
+		return bytesData.readUnsignedShort();
 	}
 
 	public function readS32LE(position: Int): Int {
 		le();
-		bytes.position = position;
-		return bytes.readInt();
+		bytesData.position = position;
+		return bytesData.readInt();
 	}
 	
 	public function readS32BE(position: Int): Int {
 		be();
-		bytes.position = position;
-		return bytes.readInt();
+		bytesData.position = position;
+		return bytesData.readInt();
 	}
 	
 	public function readU32LE(position: Int): Int {
 		le();
-		bytes.position = position;
-		return bytes.readUnsignedInt();
+		bytesData.position = position;
+		return bytesData.readUnsignedInt();
 	}
 	
 	public function readU32BE(position: Int): Int {
 		be();
-		bytes.position = position;
-		return bytes.readUnsignedInt();
+		bytesData.position = position;
+		return bytesData.readUnsignedInt();
 	}
 	
 	public function readF32LE(position: Int): Float {
 		le();
-		bytes.position = position;
-		return bytes.readFloat();
+		bytesData.position = position;
+		return bytesData.readFloat();
 	}
 	
 	public function readF32BE(position: Int): Float {
 		be();
-		bytes.position = position;
-		return bytes.readFloat();
+		bytesData.position = position;
+		return bytesData.readFloat();
 	}
 	
 	public function readF64LE(position: Int): Float {
 		le();
-		bytes.position = position;
-		return bytes.readDouble();
+		bytesData.position = position;
+		return bytesData.readDouble();
 	}
 	
 	public function readF64BE(position: Int): Float {
 		be();
-		bytes.position = position;
-		return bytes.readDouble();
+		bytesData.position = position;
+		return bytesData.readDouble();
 	}
 	
 	public function toString(): String {
-		bytes.position = 0;
-		return bytes.toString();
+		bytesData.position = 0;
+		return bytesData.toString();
 	}
 		
 	public function unload(): Void {
-		bytes = null;
+		bytesData = null;
 	}
 }

--- a/Backends/Kore/kha/Blob.hx
+++ b/Backends/Kore/kha/Blob.hx
@@ -7,7 +7,7 @@ import haxe.io.Bytes;
 ')
 
 class Blob {
-	private var bytes: Bytes;
+	public var bytes: Bytes;
 	
 	@:allow(kha.LoaderImpl)
 	private function new(bytes: Bytes) {

--- a/Sources/kha/math/FastMatrix3.hx
+++ b/Sources/kha/math/FastMatrix3.hx
@@ -35,7 +35,7 @@ class FastMatrix3 {
 		return y * width + x;
 	}*/
 
-	@:extern public inline function setFrom(m:FastMatrix3) {
+	@:extern public inline function setFrom(m:FastMatrix3): Void {
 		this._00 = m._00; this._10 = m._10; this._20 = m._20;
 		this._01 = m._01; this._11 = m._11; this._21 = m._21;
 		this._02 = m._02; this._12 = m._12; this._22 = m._22;

--- a/Sources/kha/math/FastMatrix3.hx
+++ b/Sources/kha/math/FastMatrix3.hx
@@ -35,6 +35,12 @@ class FastMatrix3 {
 		return y * width + x;
 	}*/
 
+	@:extern public inline function setFrom(m:FastMatrix3) {
+		this._00 = m._00; this._10 = m._10; this._20 = m._20;
+		this._01 = m._01; this._11 = m._11; this._21 = m._21;
+		this._02 = m._02; this._12 = m._12; this._22 = m._22;
+	}
+	
 	@:extern public static inline function translation(x: FastFloat, y: FastFloat): FastMatrix3 {
 		return new FastMatrix3(
 			1, 0, x,


### PR DESCRIPTION
FastMatrix.setFrom is useful when you want to write code like:

    transform = transform.multmat(FastMatrix3.rotation(node.rotation));
    ...
    g2.pushTransformation(transform);

With this code haxe fails to inline constructor, but with

    transform.setFrom(transform.multmat(FastMatrix3.rotation(node.rotation)));
    ...
    g2.pushTransformation(transform);

 - no allocation of heap objects occur.

As for Blob.bytes in most backends Blob.bytes is public and of type Bytes, so I made it more consistent.
