### PR TITLE
Fix depth test for CompareMode.Always.

### DIFF
--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -102,7 +102,7 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setDepthMode(write: Bool, mode: CompareMode): Void {
 		switch (mode) {
 		case Always:
-			GLES20.glDisable(GLES20.GL_DEPTH_TEST);
+			write ? GLES20.glEnable(GLES20.GL_DEPTH_TEST) : GLES20.glDisable(GLES20.GL_DEPTH_TEST);
 			GLES20.glDepthFunc(GLES20.GL_ALWAYS);
 		case Never:
 			GLES20.glEnable(GLES20.GL_DEPTH_TEST);

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -112,7 +112,7 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setDepthMode(write: Bool, mode: CompareMode): Void {
 		switch (mode) {
 		case Always:
-			SystemImpl.gl.disable(GL.DEPTH_TEST);
+			write ? SystemImpl.gl.enable(GL.DEPTH_TEST) : SystemImpl.gl.disable(GL.DEPTH_TEST);
 			SystemImpl.gl.depthFunc(GL.ALWAYS);
 		case Never:
 			SystemImpl.gl.enable(GL.DEPTH_TEST);

--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -120,7 +120,7 @@ class Graphics implements kha.graphics4.Graphics {
 	@:functionCode('
 		switch (mode) {
 		case 0:
-			Kore::Graphics::setRenderState(Kore::DepthTest, false);
+			write ? Kore::Graphics::setRenderState(Kore::DepthTest, true) : Kore::Graphics::setRenderState(Kore::DepthTest, false);
 			Kore::Graphics::setRenderState(Kore::DepthTestCompare, Kore::ZCompareAlways);
 			break;
 		case 1:

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -61,7 +61,7 @@ class Graphics implements kha.graphics4.Graphics {
 	/*@:functionCode('
 		switch (mode) {
 		case 0:
-			Kore::Graphics::setRenderState(Kore::DepthTest, false);
+			write ? Kore::Graphics::setRenderState(Kore::DepthTest, true) : Kore::Graphics::setRenderState(Kore::DepthTest, false);
 			Kore::Graphics::setRenderState(Kore::DepthTestCompare, Kore::ZCompareAlways);
 			break;
 		case 1:


### PR DESCRIPTION
Got a little puzzled till I figured this out.

Using setDepthMode(true, Always), depth will not be written because it disables depth testing. One solution I found is enabling the depth test if write is enabled, otherwise disabling it as usual.

From OpenGL docs:
"Even if the depth buffer exists and the depth mask is non-zero, the depth buffer is not updated if the depth test is disabled. In order to unconditionally write to the depth buffer, the depth test should be enabled and set to GL_ALWAYS."
(https://www.opengl.org/sdk/docs/man/docbook4/xhtml/glDepthFunc.xml)