### PR TITLE
Support local XMLHttpRequests.

### DIFF
--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -104,7 +104,8 @@ class LoaderImpl {
 		
 		request.onreadystatechange = function() {
 			if (request.readyState != 4) return;
-			if (request.status >= 200 && request.status < 400) {
+			if ((request.status >= 200 && request.status < 400) ||
+			    (request.status == 0 && request.statusText == '')) { // Blobs loaded using --allow-file-access-from-files
 				var bytes: Bytes = null;
 				var arrayBuffer = request.response;
 				if (arrayBuffer != null) {


### PR DESCRIPTION
I am loading blobs from local file system using the '--allow-file-access-from-files' chromium flag. However, these seem to return status of 0 and empty statusText on success.

This should not affect existing blob loading, and will only pass for local files when mentioned flag is enabled. Let me know what do you think.