### PR TITLE
Fix crash on Chrome when local storage is not available

### DIFF
--- a/Backends/HTML5/kha/Storage.hx
+++ b/Backends/HTML5/kha/Storage.hx
@@ -25,7 +25,11 @@ class LocalStorageFile extends StorageFile {
 	}
 	
 	override public function read(): Blob {
-		var storage: WebStorage = untyped __js__("window.localStorage");
+		var storage: WebStorage = null;
+		try {
+			storage = untyped __js__("window.localStorage");
+		}
+		catch (e: Dynamic) { }
 		if (storage == null) return null;
 		var value: String = storage.getItem(name);
 		if (value == null) return null;
@@ -33,7 +37,11 @@ class LocalStorageFile extends StorageFile {
 	}
 	
 	override public function write(data: Blob): Void {
-		var storage: WebStorage = untyped __js__("window.localStorage");
+		var storage: WebStorage = null;
+		try {
+			storage = untyped __js__("window.localStorage");
+		}
+		catch (e: Dynamic) { }
 		if (storage == null) return;
 		storage.setItem(name, encode(data.bytes.getData()));
 	}


### PR DESCRIPTION
Chrome has an option to block third-party from accessing local storage and throws an exception when trying to. This prevents the script from crashing.