### PR TITLE
Load url

### DIFF
--- a/Backends/Android/android/app/Activity.hx
+++ b/Backends/Android/android/app/Activity.hx
@@ -40,4 +40,6 @@ extern class Activity extends Context {
 	
 	@:throws("android.content.IntentSender.SendIntentException")
 	function startIntentSenderForResult(intent: IntentSender, requestCode: Int, fillInIntent: Intent, flagsMask: Int, flagsValues: Int, extraFlags: Int): Void;
+	
+	function startActivity (intent: Intent): Void;
 }

--- a/Backends/Android/android/content/Intent.hx
+++ b/Backends/Android/android/content/Intent.hx
@@ -1,8 +1,13 @@
 package android.content;
 
+import android.net.Uri;
+
 extern class Intent {
+	public static var ACTION_VIEW: String;
+	
 	@:overload public function new();
 	@:overload public function new(action: String);
+	@:overload public function new(action: String, uri: Uri);
 	
 	public function setPackage(packageName: String): Intent;
 	public function getIntExtra(name: String, defaultValue: Int): Int;

--- a/Backends/Android/android/net/Uri.hx
+++ b/Backends/Android/android/net/Uri.hx
@@ -1,0 +1,9 @@
+package android.net;
+
+import android.os.Parcelable;
+import java.lang.Comparable;
+
+extern class Uri implements Parcelable implements Comparable<Uri> {
+	public static function parse(uriString: String): Uri;
+	public function compareTo(another: Uri): Int;
+}

--- a/Backends/Android/kha/SystemImpl.hx
+++ b/Backends/Android/kha/SystemImpl.hx
@@ -1,5 +1,7 @@
 package kha;
 
+import android.content.Intent;
+import android.net.Uri;
 import com.ktxsoftware.kha.KhaActivity;
 import kha.android.Graphics;
 import kha.android.Keyboard;
@@ -303,5 +305,10 @@ class SystemImpl {
 
 	public static function setKeepScreenOn(on: Bool): Void {
 
+	}
+		
+	public static function loadUrl(url: String): Void {
+		var i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+		KhaActivity.the().startActivity(i);
 	}
 }

--- a/Backends/Flash/kha/SystemImpl.hx
+++ b/Backends/Flash/kha/SystemImpl.hx
@@ -2,6 +2,7 @@ package kha;
 
 import flash.display.StageScaleMode;
 import flash.display3D.Context3DProfile;
+import flash.net.URLRequest;
 import flash.system.Capabilities;
 import kha.flash.utils.AGALMiniAssembler;
 import kha.input.Keyboard;
@@ -331,4 +332,9 @@ class SystemImpl {
 	public static function setKeepScreenOn(on: Bool): Void {
 		
 	}
+
+	public static function loadUrl(url: String): Void {
+		Lib.getURL(new URLRequest(url), "_blank");
+	}
+	
 }

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -918,4 +918,8 @@ class SystemImpl {
 	public static function setKeepScreenOn(on: Bool): Void {
 		
 	}
+
+	public static function loadUrl(url: String): Void {
+		js.Browser.window.open(url, "_blank");
+	}
 }

--- a/Sources/kha/System.hx
+++ b/Sources/kha/System.hx
@@ -141,6 +141,6 @@ class System {
 	}
 
 	public static function loadUrl(url: String): Void {
-
+		SystemImpl.loadUrl(url);
 	}
 }


### PR DESCRIPTION
Implemented System.loadUrl for Android-Java, Flash and HTML5.

Will break backends which don't have SystemImpl.loadUrl.