### PR TITLE
Use custom canvas ID if available

### DIFF
--- a/Backends/HTML5/kha/CompilerDefines.hx
+++ b/Backends/HTML5/kha/CompilerDefines.hx
@@ -1,0 +1,8 @@
+package kha;
+
+/**
+ * This class contains references to `String` values of compiler
+ * defines specified by the khafile and khamake.
+ */
+@:build(kha.internal.CompilerDefinesBuilder.build())
+class CompilerDefines {}

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -262,7 +262,13 @@ class SystemImpl {
 	//}
 
 	private static function loadFinished() {
-		var canvas: Dynamic = Browser.document.getElementById("khanvas");
+		// Only consider custom canvas ID for release builds
+		var canvas: Dynamic = null;
+		#if (sys_debug_html5 || !canvas_id)
+		canvas = Browser.document.getElementById("khanvas");
+		#else
+		canvas = Browser.document.getElementById(kha.CompilerDefines.canvas_id);
+		#end
 		canvas.style.cursor = "default";
 
 		var gl: Bool = false;

--- a/Backends/HTML5/kha/internal/CompilerDefinesBuilder.hx
+++ b/Backends/HTML5/kha/internal/CompilerDefinesBuilder.hx
@@ -1,0 +1,47 @@
+package kha.internal;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+/**
+ * Builds public static variables with references to available
+ * compiler define values (as `String` type).
+ */
+class CompilerDefinesBuilder {
+	/**
+	 * Iterates through a map of compiler defines, and adds class fields
+	 * for every one of them.
+	 *
+	 * @return	Array of class fields.
+	 */
+	public static macro function build() : Array<Field> {
+		var fields = Context.getBuildFields();
+
+		var defines = Context.getDefines();
+
+		for (k in defines.keys()) {
+			trace(k);
+			var key = $v{k};
+			addField(fields, key, $v{Std.string(defines.get(key))});
+		}
+
+		return fields;
+	}
+
+	/**
+	 * Constructs the structure for defining a class field with public
+	 * static visibility, and pushes it to the class fields array.
+	 *
+	 * @param	fields	Array of class fields.
+	 * @param	name	Field name.
+	 * @param	value	Field value.
+	 */
+	static function addField(fields : Array<Field>, name : String, value : String) : Void {
+		fields.push({
+			name: name,
+			access: [ APublic, AStatic ],
+			kind: FVar(macro : String, macro $v{value}),
+			pos: Context.currentPos()
+		});
+	}
+}


### PR DESCRIPTION
See https://github.com/KTXSoftware/khamake/pull/87 for the related pull request.

---

If a custom canvas ID is provided via khamake, and the project is not in HTML5 debug mode, then look for the canvas element with the specified ID before initialising the application context.