### PR TITLE
html5: fix for kha.Image.fromBytes()

### DIFF
--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -157,7 +157,7 @@ class WebGLImage extends Image {
 			default:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, realWidth, realHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
 			}
-			
+
 			if (format == DEPTH16) {
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, texture, 0);
 				// OSX/Linux WebGL implementations throw incomplete framebuffer error, create color attachment
@@ -188,18 +188,18 @@ class WebGLImage extends Image {
 			case RGBA64:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, SystemImpl.halfFloat.HALF_FLOAT_OES, image);
 			case RGBA32:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, image);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, image);
 			case A32:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, myWidth, myHeight, 0, GL.ALPHA, GL.FLOAT, image);
 			case A16:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, myWidth, myHeight, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, image);
 			default:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, image);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, image);
 			}
 		}
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, null);
 	}
-	
+
 	private function initDepthStencilBuffer(depthStencilFormat: DepthStencilFormat) {
 		switch (depthStencilFormat) {
 		case NoDepthAndStencil: {}
@@ -239,7 +239,7 @@ class WebGLImage extends Image {
 				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
 				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
-			} 
+			}
 		}
 	}
 
@@ -248,12 +248,12 @@ class WebGLImage extends Image {
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, texture);
 		if (video != null) SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, video);
 	}
-	
+
 	public function setDepth(stage: Int): Void {
 		SystemImpl.gl.activeTexture(GL.TEXTURE0 + stage);
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, depthTexture);
 	}
-	
+
 	override public function setDepthStencilFrom(image: Image): Void {
 		SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 		SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, cast(image, WebGLImage).depthTexture, 0);
@@ -271,7 +271,7 @@ class WebGLImage extends Image {
 			default: 4;
 		}
 	}
-	
+
 	public function bytesToArray(bytes: Bytes): Dynamic {
 		return switch(format) {
 			case RGBA32, L8:
@@ -284,7 +284,7 @@ class WebGLImage extends Image {
 	}
 
 	public var bytes: Bytes;
-	
+
 	override public function lock(level: Int = 0): Bytes {
 		bytes = Bytes.alloc(formatByteSize(format) * width * height);
 		return bytes;

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -194,7 +194,7 @@ class WebGLImage extends Image {
 			case A16:
 				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.ALPHA, myWidth, myHeight, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, image);
 			default:
-				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, image);
+				SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, image);
 			}
 		}
 		SystemImpl.gl.bindTexture(GL.TEXTURE_2D, null);


### PR DESCRIPTION
Using kha.Image.fromBytes() explodes without the fix.

Now i'm not sure if kha.Image.fromImage() will break, as i have no idea on how to get an ImageElement to test. I think WebGLImage needs a bit of cleanup, especially the ```image: Dynamic``` so the correct texImage2d function can be called in createTexture() depending on what ```image``` actually is?

(http://api.haxe.org/js/html/webgl/RenderingContext.html#texImage2D)

(and sorry about the whitespace noise, i have autotrim in my IDE enabled)